### PR TITLE
Ver tracks en open space

### DIFF
--- a/front/src/App/OpenSpace/OpenSpace.js
+++ b/front/src/App/OpenSpace/OpenSpace.js
@@ -124,6 +124,7 @@ const OpenSpace = () => {
       finishedQueue,
       name,
       description,
+      tracks,
       organizer,
       pendingQueue,
       slots,
@@ -164,6 +165,7 @@ const OpenSpace = () => {
         <MainHeader.Title label={name} />
         <MainHeader.SubTitle icon={ScheduleIcon} label="AGENDA" />
         <MainHeader.Description description={description} />
+        <MainHeader.Tracks tracks={tracks} />
         {finishedQueue && <MainHeader.SubTitle label="Marketplace finalizado" />}
         <MainHeader.Buttons>
           {amTheOrganizer && (

--- a/front/src/shared/MainHeader.js
+++ b/front/src/shared/MainHeader.js
@@ -65,7 +65,7 @@ const Tracks = ({ children, tracks, ...props }) => (
     )}
     secondaryKey={(item) => (
       <Box width={{ max: '30vw' }}>
-        <Text color="#808080" size="small">
+        <Text color="#808080" size="small" textAlign="end">
           {item.description}
         </Text>
       </Box>

--- a/front/src/shared/MainHeader.js
+++ b/front/src/shared/MainHeader.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import PropTypes from 'prop-types';
-import { Box, Text, Button, Paragraph } from 'grommet';
+import { Box, Text, Button, Paragraph, List } from 'grommet';
 
 import MyProps from '#helpers/MyProps';
 import useSize from '#helpers/useSize';
@@ -55,6 +55,26 @@ const Description = ({ children, description, ...props }) => (
     {children}
   </Paragraph>
 );
+// itemProps={{
+//   0: { background: ['#88d2f2', 'white'] },
+//   1: { background: ['#ddaecc', 'white'] },
+// }}
+const Tracks = ({ children, tracks, ...props }) => (
+  <List
+    primaryKey={(item) => (
+      <Box background={item.color} pad="10px" margin={{ right: '100px' }}>
+        {item.name}
+      </Box>
+    )}
+    secondaryKey="description"
+    data={tracks.map((track) => {
+      return { name: track.name, description: track.description, color: track.color };
+    })}
+    pad="medium"
+  >
+    {children}
+  </List>
+);
 Description.propTypes = {
   children: MyProps.children,
   description: PropTypes.string,
@@ -74,6 +94,7 @@ const MainHeader = ({ children, ...props }) => {
   const theChildren = React.Children.toArray(children);
   const titles = getAllByTypes(theChildren, MyTitle, MyTitleLink, MySubTitle);
   const description = getByType(theChildren, Description);
+  const tracks = getByType(theChildren, Tracks);
   const buttons = getByType(theChildren, Buttons);
   return (
     <>
@@ -91,6 +112,7 @@ const MainHeader = ({ children, ...props }) => {
         {buttons}
       </RowBetween>
       {description}
+      {tracks}
     </>
   );
 };
@@ -100,6 +122,7 @@ MainHeader.Title = MyTitle;
 MainHeader.TitleLink = MyTitleLink;
 MainHeader.SubTitle = MySubTitle;
 MainHeader.Description = Description;
+MainHeader.Tracks = Tracks;
 MainHeader.Button = MyButton;
 MainHeader.ButtonNew = ButtonNew;
 MainHeader.ButtonLoading = ButtonLoading;

--- a/front/src/shared/MainHeader.js
+++ b/front/src/shared/MainHeader.js
@@ -55,18 +55,21 @@ const Description = ({ children, description, ...props }) => (
     {children}
   </Paragraph>
 );
-// itemProps={{
-//   0: { background: ['#88d2f2', 'white'] },
-//   1: { background: ['#ddaecc', 'white'] },
-// }}
+
 const Tracks = ({ children, tracks, ...props }) => (
   <List
     primaryKey={(item) => (
-      <Box background={item.color} pad="10px" margin={{ right: '100px' }}>
-        {item.name}
+      <Box background={item.color} pad="10px" margin="10px">
+        <Text>{item.name}</Text>
       </Box>
     )}
-    secondaryKey="description"
+    secondaryKey={(item) => (
+      <Box width={{ max: '30vw' }}>
+        <Text color="#808080" size="small">
+          {item.description}
+        </Text>
+      </Box>
+    )}
     data={tracks.map((track) => {
       return { name: track.name, description: track.description, color: track.color };
     })}


### PR DESCRIPTION
Los tracks ahora también se pueden ver en la pantalla principal de un Open Space.
En tamaño de pantalla 2560x1080:

![Screenshot from 2022-05-30 10-18-05](https://user-images.githubusercontent.com/43563276/171000507-0f4a75e6-c10e-4e88-be99-80a776b0a208.png)

En tamaño de pantalla 1920z1080:
![Screenshot from 2022-05-30 10-18-38](https://user-images.githubusercontent.com/43563276/171000609-3a6cee1a-cc0b-4c74-8354-9176b3229900.png)

