### PR TITLE
Orador crea charla con track

### DIFF
--- a/back/src/main/kotlin/com/sos/smartopenspace/controllers/OpenSpaceController.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/controllers/OpenSpaceController.kt
@@ -1,7 +1,7 @@
 package com.sos.smartopenspace.controllers
 
 import com.sos.smartopenspace.domain.OpenSpace
-import com.sos.smartopenspace.domain.Talk
+import com.sos.smartopenspace.helpers.CreateTalkDTO
 import com.sos.smartopenspace.services.OpenSpaceService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -19,8 +19,8 @@ class OpenSpaceController(private val openSpaceService: OpenSpaceService) {
   fun create(@PathVariable userID: Long, @Valid @RequestBody openSpace: OpenSpace) = openSpaceService.create(userID, openSpace)
 
   @PostMapping("/talk/{userID}/{osID}")
-  fun createTalk(@PathVariable userID: Long, @PathVariable osID: Long, @Valid @RequestBody talk: Talk) =
-    openSpaceService.createTalk(userID, osID, talk)
+  fun createTalk(@PathVariable userID: Long, @PathVariable osID: Long, @Valid @RequestBody createTalkDTO: CreateTalkDTO) =
+    openSpaceService.createTalk(userID, osID, createTalkDTO)
 
   @GetMapping("/user/{userID}")
   fun findAllByUser(@PathVariable userID: Long) = openSpaceService.findAllByUser(userID)

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
@@ -109,13 +109,15 @@ class OpenSpace(
   fun addTalk(talk: Talk): OpenSpace {
     checkIsFinishedQueue()
     checkIsActiveCallForPapers()
-    if (tracksDefined(talk) && !tracks.any { it == talk.track }) throw NotValidTrackForOpenSpaceException()
+    if (areTracksUsed(talk) && !trackIsFromThisOpenSpace(talk.track)) throw NotValidTrackForOpenSpaceException()
     talk.openSpace = this
     talks.add(talk)
     return this
   }
 
-  private fun tracksDefined(talk: Talk) =
+  private fun trackIsFromThisOpenSpace(track: Track?) = tracks.any { it == track }
+
+  private fun areTracksUsed(talk: Talk) =
     !(tracks.isEmpty() && talk.track == null)
 
   fun containsTalk(talk: Talk) = talks.contains(talk)

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
@@ -25,6 +25,7 @@ class TalkDoesntBelongException : RuntimeException("Charla no pertence al Open S
 class TalkIsNotForScheduledException : RuntimeException("Charla no está para agendar")
 class TalkIsNotScheduledException : RuntimeException("Charla no está agendada")
 class CallForPapersClosedException : RuntimeException("La convocatoria se encuentra cerrada")
+class NotValidTrackForOpenSpaceException : RuntimeException("El track de la charla no pertenece a este open space")
 
 @Entity
 class OpenSpace(
@@ -108,10 +109,14 @@ class OpenSpace(
   fun addTalk(talk: Talk): OpenSpace {
     checkIsFinishedQueue()
     checkIsActiveCallForPapers()
+    if (tracksDefined(talk) && !tracks.contains(talk.track)) throw NotValidTrackForOpenSpaceException()
     talk.openSpace = this
     talks.add(talk)
     return this
   }
+
+  private fun tracksDefined(talk: Talk) =
+    !(tracks.isEmpty() && talk.track == null)
 
   fun containsTalk(talk: Talk) = talks.contains(talk)
 

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
@@ -109,7 +109,7 @@ class OpenSpace(
   fun addTalk(talk: Talk): OpenSpace {
     checkIsFinishedQueue()
     checkIsActiveCallForPapers()
-    if (tracksDefined(talk) && !tracks.contains(talk.track)) throw NotValidTrackForOpenSpaceException()
+    if (tracksDefined(talk) && !tracks.any { it == talk.track }) throw NotValidTrackForOpenSpaceException()
     talk.openSpace = this
     talks.add(talk)
     return this

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
@@ -109,16 +109,20 @@ class OpenSpace(
   fun addTalk(talk: Talk): OpenSpace {
     checkIsFinishedQueue()
     checkIsActiveCallForPapers()
-    if (areTracksUsed(talk) && !trackIsFromThisOpenSpace(talk.track)) throw NotValidTrackForOpenSpaceException()
+    if (isTrackValid(talk.track))
+      throw NotValidTrackForOpenSpaceException()
     talk.openSpace = this
     talks.add(talk)
     return this
   }
 
+  private fun isTrackValid(track: Track?) =
+    areTracksUsed(track) && !trackIsFromThisOpenSpace(track)
+
   private fun trackIsFromThisOpenSpace(track: Track?) = tracks.any { it == track }
 
-  private fun areTracksUsed(talk: Talk) =
-    !(tracks.isEmpty() && talk.track == null)
+  private fun areTracksUsed(track: Track?) =
+    !(tracks.isEmpty() && track == null)
 
   fun containsTalk(talk: Talk) = talks.contains(talk)
 

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
@@ -214,7 +214,13 @@ class OpenSpace(
     checkIsOrganizer(user)
     isActiveCallForPapers = !isActiveCallForPapers
   }
+
+  @JsonProperty
+  fun amountOfTalks(): Int {
+    return talks.size
+  }
 }
+
 
 enum class QueueState {
   PENDING,

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Talk.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Talk.kt
@@ -3,11 +3,7 @@ package com.sos.smartopenspace.domain
 import com.fasterxml.jackson.annotation.JsonIgnore
 import java.net.URL
 import java.time.LocalTime
-import javax.persistence.Column
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.Id
-import javax.persistence.ManyToOne
+import javax.persistence.*
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotEmpty
@@ -28,7 +24,7 @@ class Talk(
   val meetingLink: URL? = null,
 
   @field:Valid
-  @ManyToOne
+  @ManyToOne(cascade = [CascadeType.ALL])
   val track: Track? = null
 ) {
   @ManyToOne

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Talk.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Talk.kt
@@ -24,7 +24,10 @@ class Talk(
   @GeneratedValue
   val id: Long = 0,
 
-  val meetingLink: URL? = null
+  val meetingLink: URL? = null,
+
+  @Transient
+  val track: Track? = null
 ) {
   @ManyToOne
   lateinit var speaker: User

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Talk.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Talk.kt
@@ -8,6 +8,7 @@ import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.persistence.ManyToOne
+import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotEmpty
 
@@ -26,7 +27,8 @@ class Talk(
 
   val meetingLink: URL? = null,
 
-  @Transient
+  @field:Valid
+  @ManyToOne
   val track: Track? = null
 ) {
   @ManyToOne

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Track.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Track.kt
@@ -21,4 +21,22 @@ class Track(
     @GeneratedValue
     var id: Long = 0
 ) {
+    override fun equals(other: Any?): Boolean {
+        if (other == null) return false
+
+        val otherTalk: Track = other as Track
+
+        return otherTalk.id == this.id &&
+                otherTalk.name == this.name &&
+                otherTalk.color == this.color &&
+                otherTalk.description == this.description
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + description.hashCode()
+        result = 31 * result + color.hashCode()
+        result = 31 * result + id.hashCode()
+        return result
+    }
 }

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Track.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Track.kt
@@ -1,9 +1,8 @@
 package com.sos.smartopenspace.domain
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.sos.smartopenspace.Validators.HexColor
-import javax.persistence.Entity
-import javax.persistence.GeneratedValue
-import javax.persistence.Id
+import javax.persistence.*
 import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.Size
 
@@ -21,13 +20,16 @@ class Track(
     @GeneratedValue
     var id: Long = 0
 ) {
+    @JsonIgnore
+    @OneToMany(mappedBy = "track", cascade = [CascadeType.ALL])
+    val talks: MutableSet<Talk> = mutableSetOf()
+
     override fun equals(other: Any?): Boolean {
         if (other == null) return false
 
         val otherTalk: Track = other as Track
 
-        return otherTalk.id == this.id &&
-                otherTalk.name == this.name &&
+        return otherTalk.name == this.name &&
                 otherTalk.color == this.color &&
                 otherTalk.description == this.description
     }

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Track.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Track.kt
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.Size
 
 @Entity
-class Track(
+data class Track(
     @field:NotEmpty
     val name: String,
 
@@ -23,22 +23,4 @@ class Track(
     @JsonIgnore
     @OneToMany(mappedBy = "track", cascade = [CascadeType.ALL])
     val talks: MutableSet<Talk> = mutableSetOf()
-
-    override fun equals(other: Any?): Boolean {
-        if (other == null) return false
-
-        val otherTalk: Track = other as Track
-
-        return otherTalk.name == this.name &&
-                otherTalk.color == this.color &&
-                otherTalk.description == this.description
-    }
-
-    override fun hashCode(): Int {
-        var result = name.hashCode()
-        result = 31 * result + description.hashCode()
-        result = 31 * result + color.hashCode()
-        result = 31 * result + id.hashCode()
-        return result
-    }
 }

--- a/back/src/main/kotlin/com/sos/smartopenspace/helpers/CreateTalkDTO.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/helpers/CreateTalkDTO.kt
@@ -1,0 +1,17 @@
+package com.sos.smartopenspace.helpers
+
+import java.net.URL
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotEmpty
+
+class CreateTalkDTO(
+    @field:NotEmpty(message = "Ingrese un nombre")
+    @field:NotBlank(message = "Nombre no puede ser vacío")
+    val name: String,
+
+    val description: String = "",
+
+    val meetingLink: URL? = null,
+
+    val trackId: Long? = null
+)

--- a/back/src/main/kotlin/com/sos/smartopenspace/persistence/TrackRepository.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/persistence/TrackRepository.kt
@@ -1,0 +1,6 @@
+package com.sos.smartopenspace.persistence
+
+import com.sos.smartopenspace.domain.Track
+import org.springframework.data.repository.CrudRepository
+
+interface TrackRepository : CrudRepository<Track, Long>

--- a/back/src/main/resources/db/migration/U1_8__track_for_talk.sql
+++ b/back/src/main/resources/db/migration/U1_8__track_for_talk.sql
@@ -1,0 +1,2 @@
+alter table talk
+    drop column if exists track_id;

--- a/back/src/main/resources/db/migration/V1_8__track_for_talk.sql
+++ b/back/src/main/resources/db/migration/V1_8__track_for_talk.sql
@@ -1,0 +1,4 @@
+alter table talk
+    add column if not exists track_id bigint default null;
+alter table talk
+    add foreign key (track_id) references track(id);

--- a/back/src/test/kotlin/com/sos/smartopenspace/controllers/OpenSpaceControllerTest.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/controllers/OpenSpaceControllerTest.kt
@@ -212,7 +212,7 @@ class OpenSpaceControllerTest {
         return """
             {
                 "name": "asdf",
-                "meetingLink": "$aMeeting"
+                "meetingLink": "${aMeeting}"
             }
         """.trimIndent()
     }
@@ -222,11 +222,7 @@ class OpenSpaceControllerTest {
             {
                 "name": "a talk",
                 "meetingLink": "$aMeeting",
-                "track": {
-                    "name": "${track.name}",
-                    "description": "${track.description}",
-                    "color": "${track.color}"
-                }
+                "trackId": ${track.id}
             }
         """.trimIndent()
     }

--- a/back/src/test/kotlin/com/sos/smartopenspace/domain/OpenSpaceTest.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/domain/OpenSpaceTest.kt
@@ -1,5 +1,6 @@
 package com.sos.smartopenspace.domain
 
+import com.sos.smartopenspace.anOpenSpace
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -100,7 +101,63 @@ class OpenSpaceTest {
 
         openSpace.addTalk(talk)
 
-        openSpace.containsTalk(talk)
+        assertTrue(openSpace.containsTalk(talk))
+    }
+
+    @Test
+    fun `an open space with no tracks cant add a talk with track`() {
+        val organizer = anyUser()
+        val openSpace = anyOpenSpaceWith(organizer)
+        openSpace.toggleCallForPapers(organizer)
+        val aTrack = Track(name = "track", color = "#FFFFFF")
+        val aTalk = Talk("Talk", track = aTrack)
+
+        assertThrows<NotValidTrackForOpenSpaceException> {
+            openSpace.addTalk(aTalk)
+        }
+    }
+
+    @Test
+    fun `an open space with tracks cant add a talk with a different track`() {
+        val aTrack = Track(name = "track", color = "#FFFFFF")
+        val anotherTrack = Track(name = "another track", color = "#000000")
+        val organizer = anyUser()
+        val openSpace = anOpenSpace(tracks = setOf(aTrack))
+        organizer.addOpenSpace(openSpace)
+        openSpace.toggleCallForPapers(organizer)
+        val aTalk = Talk("Talk", track = anotherTrack)
+
+        assertThrows<NotValidTrackForOpenSpaceException> {
+            openSpace.addTalk(aTalk)
+        }
+    }
+
+    @Test
+    fun `an open space with tracks cant add a talk without track`() {
+        val aTrack = Track(name = "track", color = "#FFFFFF")
+        val organizer = anyUser()
+        val openSpace = anOpenSpace(tracks = setOf(aTrack))
+        organizer.addOpenSpace(openSpace)
+        openSpace.toggleCallForPapers(organizer)
+        val aTalk = Talk("Talk")
+
+        assertThrows<NotValidTrackForOpenSpaceException> {
+            openSpace.addTalk(aTalk)
+        }
+    }
+
+    @Test
+    fun `an open space with tracks can add a talk with track`() {
+        val aTrack = Track(name = "track", color = "#FFFFFF")
+        val organizer = anyUser()
+        val openSpace = anOpenSpace(tracks = setOf(aTrack))
+        organizer.addOpenSpace(openSpace)
+        openSpace.toggleCallForPapers(organizer)
+        val aTalk = Talk("Talk", track = aTrack)
+
+        openSpace.addTalk(aTalk)
+
+        assertTrue(openSpace.containsTalk(aTalk))
     }
 
     @Test

--- a/front/src/App/EditTalk/EditTalk.js
+++ b/front/src/App/EditTalk/EditTalk.js
@@ -37,7 +37,7 @@ const EditTalk = () => {
         <MyForm.Text label="Título" placeholder="¿De que trata tu charla?" />
         <MyForm.TextArea placeholder="Describí tu charla con mas detalle..." />
         <MyForm.Link label="Link" placeholder="Link a la reunion" />
-        {openSpace && (
+        {openSpace && openSpace.tracks.length > 0 && (
           <MyForm.Select
             label="Track"
             name="trackId"

--- a/front/src/App/EditTalk/EditTalk.js
+++ b/front/src/App/EditTalk/EditTalk.js
@@ -17,6 +17,7 @@ const EditTalk = () => {
 
   if (!user || isRejected) return <RedirectToRoot />;
   if (openSpace && openSpace.finishedQueue) return <RedirectToRoot />;
+  const openSpaceHasTracks = openSpace && openSpace.tracks.length > 0;
 
   const onSubmit = ({ value: { name, description, meetingLink, trackId } }) =>
     createTalk(openSpace.id, {
@@ -37,7 +38,7 @@ const EditTalk = () => {
         <MyForm.Text label="Título" placeholder="¿De que trata tu charla?" />
         <MyForm.TextArea placeholder="Describí tu charla con mas detalle..." />
         <MyForm.Link label="Link" placeholder="Link a la reunion" />
-        {openSpace && openSpace.tracks.length > 0 && (
+        {openSpaceHasTracks && (
           <MyForm.Select
             label="Track"
             name="trackId"

--- a/front/src/App/EditTalk/EditTalk.js
+++ b/front/src/App/EditTalk/EditTalk.js
@@ -13,24 +13,39 @@ const EditTalk = () => {
   const history = useHistory();
   const user = useUser();
   const pushToMyTalks = usePushToMyTalks();
-  const { data: os, isPending, isRejected } = useGetOpenSpace();
+  const { data: openSpace, isPending, isRejected } = useGetOpenSpace();
 
   if (!user || isRejected) return <RedirectToRoot />;
-  if (os && os.finishedQueue) return <RedirectToRoot />;
+  if (openSpace && openSpace.finishedQueue) return <RedirectToRoot />;
 
-  const onSubmit = ({ value: { name, description, meetingLink } }) =>
-    createTalk(os.id, { name, description, meetingLink }).then(pushToMyTalks);
-
+  const onSubmit = ({ value: { name, description, meetingLink, trackId } }) =>
+    createTalk(openSpace.id, {
+      name,
+      description,
+      meetingLink,
+      trackId,
+    }).then(pushToMyTalks);
   return (
     <>
       <MainHeader>
         <MainHeader.Title icon={TalkIcon} label="Nueva Charla" />
-        <MainHeader.SubTitle>{isPending ? <TinySpinner /> : os.name}</MainHeader.SubTitle>
+        <MainHeader.SubTitle>
+          {isPending ? <TinySpinner /> : openSpace.name}
+        </MainHeader.SubTitle>
       </MainHeader>
       <MyForm onSecondary={history.goBack} onSubmit={onSubmit}>
         <MyForm.Text label="Título" placeholder="¿De que trata tu charla?" />
         <MyForm.TextArea placeholder="Describí tu charla con mas detalle..." />
         <MyForm.Link label="Link" placeholder="Link a la reunion" />
+        {openSpace && (
+          <MyForm.Select
+            label="Track"
+            name="trackId"
+            options={openSpace.tracks}
+            labelKey="name"
+            valueKey="id"
+          />
+        )}
       </MyForm>
     </>
   );

--- a/front/src/App/MyTalks/MyTalks.js
+++ b/front/src/App/MyTalks/MyTalks.js
@@ -42,6 +42,7 @@ function talkToModel(talk, queue, slots, openSpace) {
     talk.description,
     talk.meetingLink,
     talk.speaker,
+    talk.track,
     queue,
     slots,
     openSpace

--- a/front/src/App/MyTalks/Talk/Talk.js
+++ b/front/src/App/MyTalks/Talk/Talk.js
@@ -49,11 +49,7 @@ const Talk = ({
   const onSubmitExchange = ({ value: { time, room } }) =>
     exchangeTalk(talk.id, room.id, time).then(pushToOpenSpace);
 
-  const color = talk.track
-    ? talk.track.color
-    : talk.isAssigned()
-    ? 'status-ok'
-    : `accent-${talk.isToSchedule() ? 3 : talk.isInqueue() ? 2 : 4}`;
+  const color = talk.colorForTalkManagement();
 
   return (
     <Card borderColor={color}>

--- a/front/src/App/MyTalks/Talk/Talk.js
+++ b/front/src/App/MyTalks/Talk/Talk.js
@@ -49,7 +49,9 @@ const Talk = ({
   const onSubmitExchange = ({ value: { time, room } }) =>
     exchangeTalk(talk.id, room.id, time).then(pushToOpenSpace);
 
-  const color = talk.isAssigned()
+  const color = talk.track
+    ? talk.track.color
+    : talk.isAssigned()
     ? 'status-ok'
     : `accent-${talk.isToSchedule() ? 3 : talk.isInqueue() ? 2 : 4}`;
 

--- a/front/src/App/OpenSpace/DisplayTalks.js
+++ b/front/src/App/OpenSpace/DisplayTalks.js
@@ -7,7 +7,7 @@ import React from 'react';
 export function DisplayTalks({ amountOfTalks, activeCallForPapers, tracks }) {
   const pushToNewTalk = usePushToNewTalk();
   const shouldDisplayEmptyTalk = amountOfTalks === 0 && activeCallForPapers;
-  const shouldDisplayTrackWithTalks = tracks.length > 0;
+  const shouldDisplayTrackWithTalks = tracks.length > 0 && amountOfTalks > 0;
 
   if (shouldDisplayEmptyTalk) {
     return <EmptyTalk onClick={pushToNewTalk} />;

--- a/front/src/App/OpenSpace/DisplayTalks.js
+++ b/front/src/App/OpenSpace/DisplayTalks.js
@@ -8,12 +8,16 @@ export function DisplayTalks({ amountOfTalks, activeCallForPapers, tracks }) {
   const pushToNewTalk = usePushToNewTalk();
   const shouldDisplayEmptyTalk = amountOfTalks === 0 && activeCallForPapers;
   const shouldDisplayTrackWithTalks = tracks.length > 0;
-  if (shouldDisplayEmptyTalk) return <EmptyTalk onClick={pushToNewTalk} />;
-  else {
-    if (shouldDisplayTrackWithTalks)
-      return tracks.map((track) => (
-        <TrackWithTalks track={track} activeCallForPapers={activeCallForPapers} />
-      ));
-    else return <TalksGrid />;
+
+  if (shouldDisplayEmptyTalk) {
+    return <EmptyTalk onClick={pushToNewTalk} />;
   }
+
+  if (shouldDisplayTrackWithTalks) {
+    return tracks.map((track) => (
+      <TrackWithTalks track={track} activeCallForPapers={activeCallForPapers} />
+    ));
+  }
+
+  return <TalksGrid />;
 }

--- a/front/src/App/OpenSpace/DisplayTalks.js
+++ b/front/src/App/OpenSpace/DisplayTalks.js
@@ -1,0 +1,19 @@
+import { usePushToNewTalk } from '#helpers/routes';
+import EmptyTalk from '../MyTalks/EmptyTalk';
+import { TrackWithTalks } from './TrackWithTalks';
+import TalksGrid from './TalksGrid';
+import React from 'react';
+
+export function DisplayTalks({ amountOfTalks, activeCallForPapers, tracks }) {
+  const pushToNewTalk = usePushToNewTalk();
+  let shouldDisplayEmptyTalk = amountOfTalks === 0 && activeCallForPapers;
+  if (shouldDisplayEmptyTalk) return <EmptyTalk onClick={pushToNewTalk} />;
+  else {
+    let shouldDisplayTrackWithTalks = tracks.length > 0;
+    if (shouldDisplayTrackWithTalks)
+      return tracks.map((track) => (
+        <TrackWithTalks track={track} activeCallForPapers={activeCallForPapers} />
+      ));
+    else return <TalksGrid />;
+  }
+}

--- a/front/src/App/OpenSpace/DisplayTalks.js
+++ b/front/src/App/OpenSpace/DisplayTalks.js
@@ -6,10 +6,10 @@ import React from 'react';
 
 export function DisplayTalks({ amountOfTalks, activeCallForPapers, tracks }) {
   const pushToNewTalk = usePushToNewTalk();
-  let shouldDisplayEmptyTalk = amountOfTalks === 0 && activeCallForPapers;
+  const shouldDisplayEmptyTalk = amountOfTalks === 0 && activeCallForPapers;
+  const shouldDisplayTrackWithTalks = tracks.length > 0;
   if (shouldDisplayEmptyTalk) return <EmptyTalk onClick={pushToNewTalk} />;
   else {
-    let shouldDisplayTrackWithTalks = tracks.length > 0;
     if (shouldDisplayTrackWithTalks)
       return tracks.map((track) => (
         <TrackWithTalks track={track} activeCallForPapers={activeCallForPapers} />

--- a/front/src/App/OpenSpace/OpenSpace.js
+++ b/front/src/App/OpenSpace/OpenSpace.js
@@ -12,7 +12,6 @@ import {
 import { ScheduleIcon } from '#shared/icons';
 import MainHeader from '#shared/MainHeader';
 import Spinner from '#shared/Spinner';
-import TalksGrid from './TalksGrid';
 import { ButtonSingIn } from '#shared/ButtonSingIn';
 import { ButtonFinishMarketplace } from './buttons/ButtonFinishMarketplace';
 import { ButtonProjector } from './buttons/ButtonProjector';
@@ -20,7 +19,14 @@ import { ButtonStartMarketplace } from './buttons/ButtonStartMarketplace';
 import { ButtonToSwitchCallForPapers } from './buttons/ButtonToSwitchCallForPapers';
 import { ButtonMyTalks } from './buttons/ButtonMyTalks';
 import { QueryForm } from './QueryForm';
+import * as PropTypes from 'prop-types';
+import { TrackWithTalks } from './TrackWithTalks';
 
+TrackWithTalks.propTypes = {
+  tracks: PropTypes.any,
+  activeCallForPapers: PropTypes.any,
+  filterBy: PropTypes.func,
+};
 const OpenSpace = () => {
   const user = useUser();
   const [showQuery, setShowQuery] = useState(false);
@@ -98,7 +104,9 @@ const OpenSpace = () => {
         </MainHeader.Buttons>
       </MainHeader>
       <Box margin={{ bottom: 'medium' }}>
-        <TalksGrid isActiveCallForPapers={isActiveCallForPapers} />
+        {tracks.map((track) => (
+          <TrackWithTalks track={track} activeCallForPapers={isActiveCallForPapers} />
+        ))}
       </Box>
       {redirectToLogin && <RedirectToLoginFromOpenSpace openSpaceId={id} />}
       {showQuery && (

--- a/front/src/App/OpenSpace/OpenSpace.js
+++ b/front/src/App/OpenSpace/OpenSpace.js
@@ -19,14 +19,8 @@ import { ButtonStartMarketplace } from './buttons/ButtonStartMarketplace';
 import { ButtonToSwitchCallForPapers } from './buttons/ButtonToSwitchCallForPapers';
 import { ButtonMyTalks } from './buttons/ButtonMyTalks';
 import { QueryForm } from './QueryForm';
-import * as PropTypes from 'prop-types';
-import { TrackWithTalks } from './TrackWithTalks';
+import { DisplayTalks } from './DisplayTalks';
 
-TrackWithTalks.propTypes = {
-  tracks: PropTypes.any,
-  activeCallForPapers: PropTypes.any,
-  filterBy: PropTypes.func,
-};
 const OpenSpace = () => {
   const user = useUser();
   const [showQuery, setShowQuery] = useState(false);
@@ -42,6 +36,7 @@ const OpenSpace = () => {
       organizer,
       pendingQueue,
       isActiveCallForPapers,
+      amountOfTalks,
     } = {},
     isPending,
     isRejected,
@@ -55,7 +50,6 @@ const OpenSpace = () => {
 
   const amTheOrganizer = user && organizer.id === user.id;
   const doFinishQueue = () => finishQueue(id).then(setData);
-
   const marketPlaceButtons = () =>
     (pendingQueue && (
       <ButtonStartMarketplace onClick={() => activateQueue(id).then(setData)} />
@@ -104,9 +98,11 @@ const OpenSpace = () => {
         </MainHeader.Buttons>
       </MainHeader>
       <Box margin={{ bottom: 'medium' }}>
-        {tracks.map((track) => (
-          <TrackWithTalks track={track} activeCallForPapers={isActiveCallForPapers} />
-        ))}
+        <DisplayTalks
+          amountOfTalks={amountOfTalks}
+          activeCallForPapers={isActiveCallForPapers}
+          tracks={tracks}
+        />
       </Box>
       {redirectToLogin && <RedirectToLoginFromOpenSpace openSpaceId={id} />}
       {showQuery && (

--- a/front/src/App/OpenSpace/Talk.js
+++ b/front/src/App/OpenSpace/Talk.js
@@ -49,14 +49,15 @@ const ButtonMoreInfo = ({ onClick }) => (
 );
 ButtonMoreInfo.propTypes = { onClick: PropTypes.func.isRequired };
 
-const Talk = ({ talk: { description, name, speaker, meetingLink }, room }) => {
+const Talk = ({ talk: { description, name, speaker, track, meetingLink }, room }) => {
   const [open, setOpen] = useState(false);
 
+  const color = track ? track.color : 'accent-3';
   let shouldDisplayMoreInfo = description || meetingLink;
   return (
     <>
       <Card
-        borderColor="accent-3"
+        borderColor={color}
         height={room ? '230px' : undefined}
         margin="xsmall"
         gap="small"

--- a/front/src/App/OpenSpace/TalksGrid.js
+++ b/front/src/App/OpenSpace/TalksGrid.js
@@ -1,22 +1,17 @@
 import React from 'react';
 
 import { useGetTalks } from '#api/os-client';
-import { RedirectToRoot, usePushToNewTalk } from '#helpers/routes';
+import { RedirectToRoot } from '#helpers/routes';
 import MyGrid from '#shared/MyGrid';
 import Spinner from '#shared/Spinner';
 import Talk from './Talk';
-import EmptyTalk from '../MyTalks/EmptyTalk';
 
-const TalksGrid = ({ isActiveCallForPapers, filterBy = () => {} }) => {
+const TalksGrid = ({ filterBy = () => true }) => {
   const { data: talks, isPending, isRejected } = useGetTalks();
-  const pushToNewTalk = usePushToNewTalk();
   if (isPending) return <Spinner />;
   if (isRejected) return <RedirectToRoot />;
 
-  let shouldDisplayEmptyTalk = talks.length === 0 && isActiveCallForPapers;
-  return shouldDisplayEmptyTalk ? (
-    <EmptyTalk onClick={pushToNewTalk} />
-  ) : (
+  return (
     <MyGrid>
       {talks.filter(filterBy).map((talk) => (
         <Talk key={talk.id} talk={talk} />

--- a/front/src/App/OpenSpace/TalksGrid.js
+++ b/front/src/App/OpenSpace/TalksGrid.js
@@ -6,7 +6,9 @@ import MyGrid from '#shared/MyGrid';
 import Spinner from '#shared/Spinner';
 import Talk from './Talk';
 
-const TalksGrid = ({ filterBy = () => true }) => {
+const noCriteria = () => true;
+
+const TalksGrid = ({ filterBy = noCriteria }) => {
   const { data: talks, isPending, isRejected } = useGetTalks();
   if (isPending) return <Spinner />;
   if (isRejected) return <RedirectToRoot />;

--- a/front/src/App/OpenSpace/TalksGrid.js
+++ b/front/src/App/OpenSpace/TalksGrid.js
@@ -7,17 +7,18 @@ import Spinner from '#shared/Spinner';
 import Talk from './Talk';
 import EmptyTalk from '../MyTalks/EmptyTalk';
 
-const TalksGrid = ({ isActiveCallForPapers }) => {
+const TalksGrid = ({ isActiveCallForPapers, filterBy = () => {} }) => {
   const { data: talks, isPending, isRejected } = useGetTalks();
   const pushToNewTalk = usePushToNewTalk();
   if (isPending) return <Spinner />;
   if (isRejected) return <RedirectToRoot />;
 
-  return talks.length === 0 && isActiveCallForPapers ? (
+  let shouldDisplayEmptyTalk = talks.length === 0 && isActiveCallForPapers;
+  return shouldDisplayEmptyTalk ? (
     <EmptyTalk onClick={pushToNewTalk} />
   ) : (
     <MyGrid>
-      {talks.map((talk) => (
+      {talks.filter(filterBy).map((talk) => (
         <Talk key={talk.id} talk={talk} />
       ))}
     </MyGrid>

--- a/front/src/App/OpenSpace/TrackWithTalks.js
+++ b/front/src/App/OpenSpace/TrackWithTalks.js
@@ -13,7 +13,5 @@ export function TrackWithTalks({ track }) {
 }
 
 TrackWithTalks.propTypes = {
-  tracks: PropTypes.any,
-  activeCallForPapers: PropTypes.any,
-  filterBy: PropTypes.func,
+  track: PropTypes.object.isRequired,
 };

--- a/front/src/App/OpenSpace/TrackWithTalks.js
+++ b/front/src/App/OpenSpace/TrackWithTalks.js
@@ -1,0 +1,15 @@
+import { Heading } from 'grommet';
+import TalksGrid from './TalksGrid';
+import React from 'react';
+
+export function TrackWithTalks({ track, activeCallForPapers }) {
+  return (
+    <>
+      <Heading color={track.color}> {track.name} </Heading>
+      <TalksGrid
+        isActiveCallForPapers={activeCallForPapers}
+        filterBy={(talk) => talk.track.id === track.id}
+      />
+    </>
+  );
+}

--- a/front/src/App/OpenSpace/TrackWithTalks.js
+++ b/front/src/App/OpenSpace/TrackWithTalks.js
@@ -1,15 +1,19 @@
 import { Heading } from 'grommet';
 import TalksGrid from './TalksGrid';
 import React from 'react';
+import * as PropTypes from 'prop-types';
 
-export function TrackWithTalks({ track, activeCallForPapers }) {
+export function TrackWithTalks({ track }) {
   return (
     <>
       <Heading color={track.color}> {track.name} </Heading>
-      <TalksGrid
-        isActiveCallForPapers={activeCallForPapers}
-        filterBy={(talk) => talk.track.id === track.id}
-      />
+      <TalksGrid filterBy={(talk) => talk.track.id === track.id} />
     </>
   );
 }
+
+TrackWithTalks.propTypes = {
+  tracks: PropTypes.any,
+  activeCallForPapers: PropTypes.any,
+  filterBy: PropTypes.func,
+};

--- a/front/src/App/model/talk.js
+++ b/front/src/App/model/talk.js
@@ -42,10 +42,16 @@ export default class Talk {
   }
 
   colorForTalkManagement() {
-    return this.track
-      ? this.track.color
-      : this.isAssigned()
+    return this.hasTrack() ? this.track.color : this.colorByState();
+  }
+
+  colorByState() {
+    return this.isAssigned()
       ? 'status-ok'
       : `accent-${this.isToSchedule() ? 3 : this.isInqueue() ? 2 : 4}`;
+  }
+
+  hasTrack() {
+    return this.track;
   }
 }

--- a/front/src/App/model/talk.js
+++ b/front/src/App/model/talk.js
@@ -1,10 +1,21 @@
 export default class Talk {
-  constructor(id, name, description, meetingLink, speaker, queue, slots, openSpace) {
+  constructor(
+    id,
+    name,
+    description,
+    meetingLink,
+    speaker,
+    track,
+    queue,
+    slots,
+    openSpace
+  ) {
     this.id = id;
     this.name = name;
     this.description = description;
     this.meetingLink = meetingLink;
     this.speaker = speaker;
+    this.track = track;
     this.queue = queue;
     this.slots = slots;
     this.openSpace = openSpace;

--- a/front/src/App/model/talk.js
+++ b/front/src/App/model/talk.js
@@ -40,4 +40,12 @@ export default class Talk {
   isIn(talks) {
     return talks.some((talk) => talk.id === this.id);
   }
+
+  colorForTalkManagement() {
+    return this.track
+      ? this.track.color
+      : this.isAssigned()
+      ? 'status-ok'
+      : `accent-${this.isToSchedule() ? 3 : this.isInqueue() ? 2 : 4}`;
+  }
 }

--- a/front/src/__tests__/talk.test.js
+++ b/front/src/__tests__/talk.test.js
@@ -11,6 +11,7 @@ function anyTalk(queue = [], slots = [], openSpace = anyOpenSpaceWithNoTalksSche
       id: 1,
       name: 'speaker',
     },
+    undefined,
     queue,
     slots,
     openSpace


### PR DESCRIPTION
Las charlas si pertenecen a un Open Space con tracks, estas tienen que tener asignado uno (si o si). Por otro lado, si el open space no se maneja con tracks, la charla no tendrá la oportunidad de tener un track.


Ahora las charlas tienen el color del track al que pertenecen. 
![Screenshot from 2022-06-02 11-32-39](https://user-images.githubusercontent.com/43563276/171653664-0cd8cc59-c7c5-49f0-a5cc-9268f82f6697.png)

Si no hay tracks en ese Open Space en particular, siguen manteniendo los colores originales que tenia la página.
![Screenshot from 2022-06-02 11-34-33](https://user-images.githubusercontent.com/43563276/171653937-224274ce-0340-423a-8e4f-b6d99f81a26f.png)

