### PR TITLE
Agrupar charlas

### DIFF
--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
@@ -208,7 +208,13 @@ class OpenSpace(
     checkIsOrganizer(user)
     isActiveCallForPapers = !isActiveCallForPapers
   }
+
+  @JsonProperty
+  fun amountOfTalks(): Int {
+    return talks.size
+  }
 }
+
 
 enum class QueueState {
   PENDING,

--- a/front/src/App/OpenSpace/DisplayTalks.js
+++ b/front/src/App/OpenSpace/DisplayTalks.js
@@ -7,7 +7,7 @@ import React from 'react';
 export function DisplayTalks({ amountOfTalks, activeCallForPapers, tracks }) {
   const pushToNewTalk = usePushToNewTalk();
   const shouldDisplayEmptyTalk = amountOfTalks === 0 && activeCallForPapers;
-  const shouldDisplayTrackWithTalks = tracks.length > 0;
+  const shouldDisplayTrackWithTalks = tracks.length > 0 && amountOfTalks > 0;
 
   if (shouldDisplayEmptyTalk) {
     return <EmptyTalk onClick={pushToNewTalk} />;

--- a/front/src/App/OpenSpace/DisplayTalks.js
+++ b/front/src/App/OpenSpace/DisplayTalks.js
@@ -8,12 +8,16 @@ export function DisplayTalks({ amountOfTalks, activeCallForPapers, tracks }) {
   const pushToNewTalk = usePushToNewTalk();
   const shouldDisplayEmptyTalk = amountOfTalks === 0 && activeCallForPapers;
   const shouldDisplayTrackWithTalks = tracks.length > 0;
-  if (shouldDisplayEmptyTalk) return <EmptyTalk onClick={pushToNewTalk} />;
-  else {
-    if (shouldDisplayTrackWithTalks)
-      return tracks.map((track) => (
-        <TrackWithTalks track={track} activeCallForPapers={activeCallForPapers} />
-      ));
-    else return <TalksGrid />;
+
+  if (shouldDisplayEmptyTalk) {
+    return <EmptyTalk onClick={pushToNewTalk} />;
   }
+
+  if (shouldDisplayTrackWithTalks) {
+    return tracks.map((track) => (
+      <TrackWithTalks track={track} activeCallForPapers={activeCallForPapers} />
+    ));
+  }
+
+  return <TalksGrid />;
 }

--- a/front/src/App/OpenSpace/DisplayTalks.js
+++ b/front/src/App/OpenSpace/DisplayTalks.js
@@ -1,0 +1,19 @@
+import { usePushToNewTalk } from '#helpers/routes';
+import EmptyTalk from '../MyTalks/EmptyTalk';
+import { TrackWithTalks } from './TrackWithTalks';
+import TalksGrid from './TalksGrid';
+import React from 'react';
+
+export function DisplayTalks({ amountOfTalks, activeCallForPapers, tracks }) {
+  const pushToNewTalk = usePushToNewTalk();
+  let shouldDisplayEmptyTalk = amountOfTalks === 0 && activeCallForPapers;
+  if (shouldDisplayEmptyTalk) return <EmptyTalk onClick={pushToNewTalk} />;
+  else {
+    let shouldDisplayTrackWithTalks = tracks.length > 0;
+    if (shouldDisplayTrackWithTalks)
+      return tracks.map((track) => (
+        <TrackWithTalks track={track} activeCallForPapers={activeCallForPapers} />
+      ));
+    else return <TalksGrid />;
+  }
+}

--- a/front/src/App/OpenSpace/DisplayTalks.js
+++ b/front/src/App/OpenSpace/DisplayTalks.js
@@ -6,10 +6,10 @@ import React from 'react';
 
 export function DisplayTalks({ amountOfTalks, activeCallForPapers, tracks }) {
   const pushToNewTalk = usePushToNewTalk();
-  let shouldDisplayEmptyTalk = amountOfTalks === 0 && activeCallForPapers;
+  const shouldDisplayEmptyTalk = amountOfTalks === 0 && activeCallForPapers;
+  const shouldDisplayTrackWithTalks = tracks.length > 0;
   if (shouldDisplayEmptyTalk) return <EmptyTalk onClick={pushToNewTalk} />;
   else {
-    let shouldDisplayTrackWithTalks = tracks.length > 0;
     if (shouldDisplayTrackWithTalks)
       return tracks.map((track) => (
         <TrackWithTalks track={track} activeCallForPapers={activeCallForPapers} />

--- a/front/src/App/OpenSpace/OpenSpace.js
+++ b/front/src/App/OpenSpace/OpenSpace.js
@@ -12,7 +12,6 @@ import {
 import { ScheduleIcon } from '#shared/icons';
 import MainHeader from '#shared/MainHeader';
 import Spinner from '#shared/Spinner';
-import TalksGrid from './TalksGrid';
 import { ButtonSingIn } from '#shared/ButtonSingIn';
 import { ButtonFinishMarketplace } from './buttons/ButtonFinishMarketplace';
 import { ButtonProjector } from './buttons/ButtonProjector';
@@ -20,7 +19,14 @@ import { ButtonStartMarketplace } from './buttons/ButtonStartMarketplace';
 import { ButtonToSwitchCallForPapers } from './buttons/ButtonToSwitchCallForPapers';
 import { ButtonMyTalks } from './buttons/ButtonMyTalks';
 import { QueryForm } from './QueryForm';
+import * as PropTypes from 'prop-types';
+import { TrackWithTalks } from './TrackWithTalks';
 
+TrackWithTalks.propTypes = {
+  tracks: PropTypes.any,
+  activeCallForPapers: PropTypes.any,
+  filterBy: PropTypes.func,
+};
 const OpenSpace = () => {
   const user = useUser();
   const [showQuery, setShowQuery] = useState(false);
@@ -98,7 +104,9 @@ const OpenSpace = () => {
         </MainHeader.Buttons>
       </MainHeader>
       <Box margin={{ bottom: 'medium' }}>
-        <TalksGrid isActiveCallForPapers={isActiveCallForPapers} />
+        {tracks.map((track) => (
+          <TrackWithTalks track={track} activeCallForPapers={isActiveCallForPapers} />
+        ))}
       </Box>
       {redirectToLogin && <RedirectToLoginFromOpenSpace openSpaceId={id} />}
       {showQuery && (

--- a/front/src/App/OpenSpace/OpenSpace.js
+++ b/front/src/App/OpenSpace/OpenSpace.js
@@ -19,14 +19,8 @@ import { ButtonStartMarketplace } from './buttons/ButtonStartMarketplace';
 import { ButtonToSwitchCallForPapers } from './buttons/ButtonToSwitchCallForPapers';
 import { ButtonMyTalks } from './buttons/ButtonMyTalks';
 import { QueryForm } from './QueryForm';
-import * as PropTypes from 'prop-types';
-import { TrackWithTalks } from './TrackWithTalks';
+import { DisplayTalks } from './DisplayTalks';
 
-TrackWithTalks.propTypes = {
-  tracks: PropTypes.any,
-  activeCallForPapers: PropTypes.any,
-  filterBy: PropTypes.func,
-};
 const OpenSpace = () => {
   const user = useUser();
   const [showQuery, setShowQuery] = useState(false);
@@ -42,6 +36,7 @@ const OpenSpace = () => {
       organizer,
       pendingQueue,
       isActiveCallForPapers,
+      amountOfTalks,
     } = {},
     isPending,
     isRejected,
@@ -55,7 +50,6 @@ const OpenSpace = () => {
 
   const amTheOrganizer = user && organizer.id === user.id;
   const doFinishQueue = () => finishQueue(id).then(setData);
-
   const marketPlaceButtons = () =>
     (pendingQueue && (
       <ButtonStartMarketplace onClick={() => activateQueue(id).then(setData)} />
@@ -104,9 +98,11 @@ const OpenSpace = () => {
         </MainHeader.Buttons>
       </MainHeader>
       <Box margin={{ bottom: 'medium' }}>
-        {tracks.map((track) => (
-          <TrackWithTalks track={track} activeCallForPapers={isActiveCallForPapers} />
-        ))}
+        <DisplayTalks
+          amountOfTalks={amountOfTalks}
+          activeCallForPapers={isActiveCallForPapers}
+          tracks={tracks}
+        />
       </Box>
       {redirectToLogin && <RedirectToLoginFromOpenSpace openSpaceId={id} />}
       {showQuery && (

--- a/front/src/App/OpenSpace/TalksGrid.js
+++ b/front/src/App/OpenSpace/TalksGrid.js
@@ -1,22 +1,17 @@
 import React from 'react';
 
 import { useGetTalks } from '#api/os-client';
-import { RedirectToRoot, usePushToNewTalk } from '#helpers/routes';
+import { RedirectToRoot } from '#helpers/routes';
 import MyGrid from '#shared/MyGrid';
 import Spinner from '#shared/Spinner';
 import Talk from './Talk';
-import EmptyTalk from '../MyTalks/EmptyTalk';
 
-const TalksGrid = ({ isActiveCallForPapers, filterBy = () => {} }) => {
+const TalksGrid = ({ filterBy = () => true }) => {
   const { data: talks, isPending, isRejected } = useGetTalks();
-  const pushToNewTalk = usePushToNewTalk();
   if (isPending) return <Spinner />;
   if (isRejected) return <RedirectToRoot />;
 
-  let shouldDisplayEmptyTalk = talks.length === 0 && isActiveCallForPapers;
-  return shouldDisplayEmptyTalk ? (
-    <EmptyTalk onClick={pushToNewTalk} />
-  ) : (
+  return (
     <MyGrid>
       {talks.filter(filterBy).map((talk) => (
         <Talk key={talk.id} talk={talk} />

--- a/front/src/App/OpenSpace/TalksGrid.js
+++ b/front/src/App/OpenSpace/TalksGrid.js
@@ -6,7 +6,9 @@ import MyGrid from '#shared/MyGrid';
 import Spinner from '#shared/Spinner';
 import Talk from './Talk';
 
-const TalksGrid = ({ filterBy = () => true }) => {
+const noCriteria = () => true;
+
+const TalksGrid = ({ filterBy = noCriteria }) => {
   const { data: talks, isPending, isRejected } = useGetTalks();
   if (isPending) return <Spinner />;
   if (isRejected) return <RedirectToRoot />;

--- a/front/src/App/OpenSpace/TalksGrid.js
+++ b/front/src/App/OpenSpace/TalksGrid.js
@@ -7,17 +7,18 @@ import Spinner from '#shared/Spinner';
 import Talk from './Talk';
 import EmptyTalk from '../MyTalks/EmptyTalk';
 
-const TalksGrid = ({ isActiveCallForPapers }) => {
+const TalksGrid = ({ isActiveCallForPapers, filterBy = () => {} }) => {
   const { data: talks, isPending, isRejected } = useGetTalks();
   const pushToNewTalk = usePushToNewTalk();
   if (isPending) return <Spinner />;
   if (isRejected) return <RedirectToRoot />;
 
-  return talks.length === 0 && isActiveCallForPapers ? (
+  let shouldDisplayEmptyTalk = talks.length === 0 && isActiveCallForPapers;
+  return shouldDisplayEmptyTalk ? (
     <EmptyTalk onClick={pushToNewTalk} />
   ) : (
     <MyGrid>
-      {talks.map((talk) => (
+      {talks.filter(filterBy).map((talk) => (
         <Talk key={talk.id} talk={talk} />
       ))}
     </MyGrid>

--- a/front/src/App/OpenSpace/TrackWithTalks.js
+++ b/front/src/App/OpenSpace/TrackWithTalks.js
@@ -13,7 +13,5 @@ export function TrackWithTalks({ track }) {
 }
 
 TrackWithTalks.propTypes = {
-  tracks: PropTypes.any,
-  activeCallForPapers: PropTypes.any,
-  filterBy: PropTypes.func,
+  track: PropTypes.object.isRequired,
 };

--- a/front/src/App/OpenSpace/TrackWithTalks.js
+++ b/front/src/App/OpenSpace/TrackWithTalks.js
@@ -1,0 +1,15 @@
+import { Heading } from 'grommet';
+import TalksGrid from './TalksGrid';
+import React from 'react';
+
+export function TrackWithTalks({ track, activeCallForPapers }) {
+  return (
+    <>
+      <Heading color={track.color}> {track.name} </Heading>
+      <TalksGrid
+        isActiveCallForPapers={activeCallForPapers}
+        filterBy={(talk) => talk.track.id === track.id}
+      />
+    </>
+  );
+}

--- a/front/src/App/OpenSpace/TrackWithTalks.js
+++ b/front/src/App/OpenSpace/TrackWithTalks.js
@@ -1,15 +1,19 @@
 import { Heading } from 'grommet';
 import TalksGrid from './TalksGrid';
 import React from 'react';
+import * as PropTypes from 'prop-types';
 
-export function TrackWithTalks({ track, activeCallForPapers }) {
+export function TrackWithTalks({ track }) {
   return (
     <>
       <Heading color={track.color}> {track.name} </Heading>
-      <TalksGrid
-        isActiveCallForPapers={activeCallForPapers}
-        filterBy={(talk) => talk.track.id === track.id}
-      />
+      <TalksGrid filterBy={(talk) => talk.track.id === track.id} />
     </>
   );
 }
+
+TrackWithTalks.propTypes = {
+  tracks: PropTypes.any,
+  activeCallForPapers: PropTypes.any,
+  filterBy: PropTypes.func,
+};


### PR DESCRIPTION
Antes veiamos todas las charlas, con o sin track, en una grilla. Ahora cuando hay tracks las agrupamos por tracks de la siguiente forma
![Screenshot from 2022-06-02 12-37-44](https://user-images.githubusercontent.com/16313890/171667093-0064d719-36c9-44f3-bd85-a058cf2469dd.png)
En caso de haber algun track sin charlas:
![Screenshot from 2022-06-02 12-55-59](https://user-images.githubusercontent.com/16313890/171672458-ef04c4ff-6360-4d83-bfc6-b767b9540c6e.png)
Luego si no hay tracks
![Screenshot from 2022-06-02 12-56-22](https://user-images.githubusercontent.com/16313890/171672583-637a8b80-eb2b-45be-9c2e-a55d88bdfcfc.png)
Y si no hubiese charlas pero si tracks
![Screenshot from 2022-06-02 12-56-49](https://user-images.githubusercontent.com/16313890/171672748-c71e498c-2421-4494-b74a-d824cd1c2708.png)
Y ni charlas ni tracks
![Screenshot from 2022-06-02 12-57-16](https://user-images.githubusercontent.com/16313890/171672904-2596eba2-3915-4621-a0c5-cfb783a4ae29.png)
