### PR TITLE
HOT FIX: Se pueden ver las charlas en la agenda

### DIFF
--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Talk.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Talk.kt
@@ -29,7 +29,7 @@ class Talk(
   val track: Track? = null
 ) {
 
-  @ManyToMany(cascade = [CascadeType.ALL])
+  @ManyToMany(fetch = FetchType.EAGER, cascade = [CascadeType.ALL])
   @JoinTable(name = "vote",
           joinColumns = [JoinColumn(name = "talk_id", referencedColumnName = "id")],
           inverseJoinColumns = [JoinColumn(name = "user_id", referencedColumnName = "id")])


### PR DESCRIPTION
Habia un problema que al cargar de forma lazy los votantes de una charla, no se enviaban a través del websocket para verse desde el front. Haciendo que las charlas no se pudieran ver en la agenda. La solución momentánea es fetchear desde la base de datos todos los usuarios votantes para poder enviar las charlas a través del websocket de forma exitosa. 
Previo al merge con master no hubo ningún problema con el fetch lazy, al momento de mergear con master empezaron a surgir los problemas mencionados, y no sabemos el porqué. Si tienen una explicación para este fenomeno o alguna solución mejor, serán bienvenidxs.