### PR TITLE
Arreglo al registrarse

### DIFF
--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/User.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/User.kt
@@ -28,10 +28,9 @@ class User(
   @field:NotBlank(message = "Nombre no puede ser vacío")
   val name: String,
 
-  // @field:NotEmpty(message = "Ingrese una contraseña")
-  // @field:NotBlank(message = "Contraseña no puede ser vacía")
+  @field:NotEmpty(message = "Ingrese una contraseña")
+  @field:NotBlank(message = "Contraseña no puede ser vacía")
   @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
-  @JsonIgnore
   var password: String = "",
 
   @field:Valid

--- a/back/src/test/kotlin/com/sos/smartopenspace/controllers/UserControllerTest.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/controllers/UserControllerTest.kt
@@ -57,9 +57,16 @@ class UserControllerTest {
 
   @Test
   fun `user login returns ok status response`() {
-    val email = "email@gmail.com"
-    val password = "password"
-    userService.create(User(email= email, name = "Fran", password = password))
+      val email = "email@gmail.com"
+      val password = "password"
+      val name = "Fran"
+      val userInformation = anUserCreationBody(email = email, password = password, name = name)
+
+      mockMvc.perform(
+              MockMvcRequestBuilders.post("/user")
+                      .contentType("application/json")
+                      .content(userInformation)
+      )
 
     val userLoginInformation = """
           {


### PR DESCRIPTION
Cuando se registraba se guardaba una contraseña vacia por lo que al momento de loguearse no se encontraba al usuario