### PR TITLE
Specify node version in package json

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3

--- a/front/package.json
+++ b/front/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/AugustoConti/smart-open-space.git",
     "directory": "front"
   },
+  "engines": {
+    "node": "16.x"
+  },
   "scripts": {
     "lint": "eslint ./src",
     "lint:fix": "eslint --fix ./src",

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -2355,9 +2355,9 @@ camelize@^1.0.0:
   integrity "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs= sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
 
 caniuse-lite@^1.0.30001038:
-  version "1.0.30001038"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz"
-  integrity sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ==
+  version "1.0.30001423"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz"
+  integrity sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Problema

Los builds de Heroku están fallando porque automáticamente Heroku siempre esta tomando la ultima version de node, y en este momento la Node 18.11 no esta funcionando.

### Solución

Nuestra intención era usar Node 16, así que este PR especifica eso en el package.json que según las guías de Heroku es lo que necesita el buildpack de node para usar esa versión LTS y no siempre la última. 