### PR TITLE
edit open space

### DIFF
--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
@@ -20,7 +20,7 @@ class OpenSpace(
   @field:NotEmpty(message = "Ingrese al menos una sala")
   @OneToMany(cascade = [CascadeType.ALL])
   @JoinColumn(name = "open_space_id")
-  var rooms: MutableSet<Room>,
+  val rooms: MutableSet<Room>,
 
   @field:Valid
   @field:NotEmpty(message = "Ingrese al menos un slot")
@@ -40,7 +40,7 @@ class OpenSpace(
   @field:Valid
   @OneToMany(cascade = [CascadeType.ALL])
   @JoinColumn(name = "open_space_id")
-  val tracks: MutableSet<Track> = emptySet<Track>().toMutableSet(),
+  val tracks: MutableSet<Track> = mutableSetOf(),
 
   val urlImage: String = "",
 
@@ -272,8 +272,8 @@ class OpenSpace(
   }
 
   fun removeInvalidAssignedSlots() {
-    val existingRoomIds =this.rooms.map { it.id }
-    val existingSlotIds =this.slots.map { it.id }
+    val existingRoomIds = this.rooms.map { it.id }
+    val existingSlotIds = this.slots.map { it.id }
     this.assignedSlots.removeIf { !existingRoomIds.contains(it.room.id) || !existingSlotIds.contains(it.slot.id) }
   }
 }

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
@@ -20,13 +20,13 @@ class OpenSpace(
   @field:NotEmpty(message = "Ingrese al menos una sala")
   @OneToMany(cascade = [CascadeType.ALL])
   @JoinColumn(name = "open_space_id")
-  val rooms: Set<Room>,
+  var rooms: MutableSet<Room>,
 
   @field:Valid
   @field:NotEmpty(message = "Ingrese al menos un slot")
   @OneToMany(cascade = [CascadeType.ALL])
   @JoinColumn(name = "open_space_id")
-  val slots: Set<Slot>,
+  val slots: MutableSet<Slot>,
 
   @JsonIgnore
   @field:Valid
@@ -35,12 +35,12 @@ class OpenSpace(
 
   @field:Column(length = 1000)
   @field:Size(min = 0, max = 1000)
-  val description: String = "",
+  var description: String = "",
 
   @field:Valid
   @OneToMany(cascade = [CascadeType.ALL])
   @JoinColumn(name = "open_space_id")
-  val tracks: Set<Track> = emptySet(),
+  val tracks: MutableSet<Track> = emptySet<Track>().toMutableSet(),
 
   val urlImage: String = "",
 
@@ -243,12 +243,35 @@ class OpenSpace(
     return assignedSlots.isNotEmpty()
   }
 
-  fun update(user: User, name: String) {
+  fun update(user: User, name: String, description: String) {
     checkIsOrganizer(user)
     this.name = name
+    this.description = description
   }
-}
 
+  fun updateRooms(newRooms: Set<Room>) : List<Room> {
+    return this.updateCollection(newRooms, this.rooms)
+  }
+
+  fun updateSlots(newSlots: Set<Slot>) : List<Slot>{
+    return this.updateCollection(newSlots, this.slots)
+  }
+
+  fun updateTracks(newTracks: Set<Track>) : List<Track> {
+    return this.updateCollection(newTracks, this.tracks)
+  }
+  private fun <T : OpenSpaceItemCollection> updateCollection(items: Set<T>, currentItems:  MutableSet<T>) : List<T>  {
+    val newItems = items.filter { it.id.toInt() ==  0 }
+    val remainingItemIds = items.map { it.id }
+    val deletedItems = currentItems.filterNot { remainingItemIds.contains(it.id)}
+
+    currentItems.removeAll(deletedItems.toSet())
+    currentItems.addAll(newItems)
+
+    return deletedItems
+  }
+
+}
 
 enum class QueueState {
   PENDING,

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpace.kt
@@ -271,6 +271,11 @@ class OpenSpace(
     return deletedItems
   }
 
+  fun removeInvalidAssignedSlots() {
+    val existingRoomIds =this.rooms.map { it.id }
+    val existingSlotIds =this.slots.map { it.id }
+    this.assignedSlots.removeIf { !existingRoomIds.contains(it.room.id) || !existingSlotIds.contains(it.slot.id) }
+  }
 }
 
 enum class QueueState {

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpaceItemCollection.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpaceItemCollection.kt
@@ -1,0 +1,5 @@
+package com.sos.smartopenspace.domain
+
+abstract class OpenSpaceItemCollection {
+    abstract val id: Long
+}

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpaceItemCollection.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/OpenSpaceItemCollection.kt
@@ -1,5 +1,5 @@
 package com.sos.smartopenspace.domain
 
-abstract class OpenSpaceItemCollection {
-    abstract val id: Long
+interface OpenSpaceItemCollection {
+  val id: Long
 }

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Room.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Room.kt
@@ -9,7 +9,7 @@ import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotEmpty
 
 @Entity
-class Room(
+class Room (
   @field:NotEmpty(message = "Ingrese un nombre")
   @field:NotBlank(message = "Nombre no puede ser vacío")
   val name: String,
@@ -21,5 +21,5 @@ class Room(
   var link: URL? = null,
 
   @Id @GeneratedValue
-  val id: Long = 0
-)
+  override val id: Long = 0
+) : OpenSpaceItemCollection()

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Room.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Room.kt
@@ -22,4 +22,4 @@ class Room (
 
   @Id @GeneratedValue
   override val id: Long = 0
-) : OpenSpaceItemCollection()
+) : OpenSpaceItemCollection

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Slot.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Slot.kt
@@ -25,7 +25,7 @@ abstract class Slot(
   @Id
   @GeneratedValue
   override val id: Long = 0
-) : OpenSpaceItemCollection() {
+) : OpenSpaceItemCollection {
   abstract fun isAssignable(): Boolean
   abstract fun cloneWithDate(date: LocalDate): Slot
 }

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Slot.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Slot.kt
@@ -1,5 +1,4 @@
 package com.sos.smartopenspace.domain
-
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.JsonTypeInfo
@@ -19,13 +18,14 @@ import javax.persistence.OneToOne
 @Entity
 abstract class Slot(
   val startTime: LocalTime,
+
   val endTime: LocalTime,
 
   val date: LocalDate? = null,
   @Id
   @GeneratedValue
-  val id: Long = 0
-) {
+  override val id: Long = 0
+) : OpenSpaceItemCollection() {
   abstract fun isAssignable(): Boolean
   abstract fun cloneWithDate(date: LocalDate): Slot
 }

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Track.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Track.kt
@@ -19,7 +19,7 @@ data class Track(
     @Id
     @GeneratedValue
     override var id: Long = 0
-) : OpenSpaceItemCollection() {
+) : OpenSpaceItemCollection {
     @JsonIgnore
     @OneToMany(mappedBy = "track", cascade = [CascadeType.ALL])
     val talks: MutableSet<Talk> = mutableSetOf()

--- a/back/src/main/kotlin/com/sos/smartopenspace/domain/Track.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/domain/Track.kt
@@ -18,8 +18,8 @@ data class Track(
     val color: String,
     @Id
     @GeneratedValue
-    var id: Long = 0
-) {
+    override var id: Long = 0
+) : OpenSpaceItemCollection() {
     @JsonIgnore
     @OneToMany(mappedBy = "track", cascade = [CascadeType.ALL])
     val talks: MutableSet<Talk> = mutableSetOf()

--- a/back/src/main/kotlin/com/sos/smartopenspace/services/DataService.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/services/DataService.kt
@@ -59,8 +59,8 @@ class DataService(private val userRepository: UserRepository) {
     val room37b = Room("Aula 37b")
     val cpi = OpenSpace(
       "CPI-Conf",
-      setOf(room213, room60, room37b),
-      setOf(
+      mutableSetOf(room213, room60, room37b),
+      mutableSetOf(
         OtherSlot(LocalTime.parse("14:00"), LocalTime.parse("14:30"), "Marketplace", date),
         TalkSlot(LocalTime.parse("14:30"), LocalTime.parse("15:00"), date),
         TalkSlot(LocalTime.parse("15:00"), LocalTime.parse("16:00"), date),
@@ -94,10 +94,10 @@ class DataService(private val userRepository: UserRepository) {
 
     val practicas = OpenSpace(
       "Prácticas Técnicas - 4° edición",
-      setOf(roja, amarilla, verde, naranja),
+      mutableSetOf(roja, amarilla, verde, naranja),
       (19..21).map {
         TalkSlot(LocalTime.of(it, 0), LocalTime.of(it + 1, 0), LocalDate.now())
-      }.toSet(),
+      }.toMutableSet(),
       mutableSetOf(master, front, judo, testear, contrato, appLenta, troika, flutter),
       "https://secure.meetupstatic.com/photos/event/7/1/a/f/highres_482189103.jpeg"
     )
@@ -105,10 +105,10 @@ class DataService(private val userRepository: UserRepository) {
     val charla1 = Talk("Charla 1")
     val os1 = OpenSpace(
       "OS 1",
-      setOf(Room("Sala 1")),
+      mutableSetOf(Room("Sala 1")),
       (19..21).map {
         TalkSlot(LocalTime.of(it, 0), LocalTime.of(it + 1, 0), LocalDate.now())
-      }.toSet(),
+      }.toMutableSet(),
       mutableSetOf(charla1)
     )
 

--- a/back/src/main/kotlin/com/sos/smartopenspace/services/OpenSpaceService.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/services/OpenSpaceService.kt
@@ -3,9 +3,7 @@ package com.sos.smartopenspace.services
 import com.sos.smartopenspace.domain.*
 import com.sos.smartopenspace.helpers.CreateTalkDTO
 import com.sos.smartopenspace.helpers.OpenSpaceDTO
-import com.sos.smartopenspace.persistence.OpenSpaceRepository
-import com.sos.smartopenspace.persistence.TalkRepository
-import com.sos.smartopenspace.persistence.TrackRepository
+import com.sos.smartopenspace.persistence.*
 import com.sos.smartopenspace.websockets.QueueSocket
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -26,33 +24,44 @@ class OpenSpaceService(
     val slots = openSpaceDTO.slotsWithDates()
     val openSpace = OpenSpace(
       name = openSpaceDTO.name,
-      rooms = openSpaceDTO.rooms,
-      slots = slots.toSet(),
+      rooms = openSpaceDTO.rooms.toMutableSet(),
+      slots = slots.toMutableSet(),
       description = openSpaceDTO.description,
-      tracks = openSpaceDTO.tracks
+      tracks = openSpaceDTO.tracks.toMutableSet()
     )
     findUser(userID).addOpenSpace(openSpace)
     return openSpaceRepository.save(openSpace)
   }
 
+  @Transactional
   fun update(userID: Long, openSpaceID: Long, openSpaceDTO: OpenSpaceDTO): OpenSpace? {
     val openSpace = findById(openSpaceID)
     val user = findUser(userID)
-    openSpace.update(user, openSpaceDTO.name)
+
+    openSpace.updateRooms(openSpaceDTO.rooms)
+    openSpace.updateSlots(openSpaceDTO.slots)
+    openSpace.updateTracks(openSpaceDTO.tracks)
+
+    openSpace.update(
+      user,
+      name = openSpaceDTO.name,
+      description = openSpaceDTO.description
+    )
+
     return openSpace
   }
   
   @Transactional
   fun delete(userID: Long, openSpaceID: Long): Long {
-    val user = findUser(userID);
-    val openSpace = findById(openSpaceID);
+    val user = findUser(userID)
+    val openSpace = findById(openSpaceID)
 
-    user.checkOwnershipOf(openSpace);
+    user.checkOwnershipOf(openSpace)
 
-    user.removeOpenSpace(openSpace);
-    openSpaceRepository.delete(openSpace);
+    user.removeOpenSpace(openSpace)
+    openSpaceRepository.delete(openSpace)
 
-    return openSpace.id;
+    return openSpace.id
   }
 
   @Transactional(readOnly = true)

--- a/back/src/main/kotlin/com/sos/smartopenspace/services/OpenSpaceService.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/services/OpenSpaceService.kt
@@ -21,11 +21,10 @@ class OpenSpaceService(
   private fun findUser(userID: Long) = userService.findById(userID)
 
   fun create(userID: Long, openSpaceDTO: OpenSpaceDTO): OpenSpace {
-    val slots = openSpaceDTO.slotsWithDates()
     val openSpace = OpenSpace(
       name = openSpaceDTO.name,
       rooms = openSpaceDTO.rooms.toMutableSet(),
-      slots = slots.toMutableSet(),
+      slots = openSpaceDTO.slots.toMutableSet(),
       description = openSpaceDTO.description,
       tracks = openSpaceDTO.tracks.toMutableSet()
     )

--- a/back/src/main/kotlin/com/sos/smartopenspace/services/OpenSpaceService.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/services/OpenSpaceService.kt
@@ -40,6 +40,7 @@ class OpenSpaceService(
     openSpace.updateRooms(openSpaceDTO.rooms)
     openSpace.updateSlots(openSpaceDTO.slots)
     openSpace.updateTracks(openSpaceDTO.tracks)
+    openSpace.removeInvalidAssignedSlots()
 
     openSpace.update(
       user,

--- a/back/src/main/kotlin/com/sos/smartopenspace/services/OpenSpaceService.kt
+++ b/back/src/main/kotlin/com/sos/smartopenspace/services/OpenSpaceService.kt
@@ -32,7 +32,6 @@ class OpenSpaceService(
     return openSpaceRepository.save(openSpace)
   }
 
-  @Transactional
   fun update(userID: Long, openSpaceID: Long, openSpaceDTO: OpenSpaceDTO): OpenSpace? {
     val openSpace = findById(openSpaceID)
     val user = findUser(userID)
@@ -50,8 +49,7 @@ class OpenSpaceService(
 
     return openSpace
   }
-  
-  @Transactional
+
   fun delete(userID: Long, openSpaceID: Long): Long {
     val user = findUser(userID)
     val openSpace = findById(openSpaceID)

--- a/back/src/test/kotlin/com/sos/smartopenspace/TestingObjectFactory.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/TestingObjectFactory.kt
@@ -21,11 +21,11 @@ fun anOpenSpace(
 ): OpenSpace {
     return OpenSpace(
       name = name,
-      rooms = rooms,
-      slots = slots,
+      rooms = rooms.toMutableSet(),
+      slots = slots.toMutableSet(),
       talks = talks,
       description = description,
-      tracks = tracks
+      tracks = tracks.toMutableSet()
     )
 }
 

--- a/back/src/test/kotlin/com/sos/smartopenspace/domain/OpenSpaceTest.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/domain/OpenSpaceTest.kt
@@ -12,7 +12,7 @@ class OpenSpaceTest {
 
     private fun anyOpenSpace(talks: MutableSet<Talk> = mutableSetOf()) =
         OpenSpace(
-            "os", emptySet(), setOf(
+            "os", emptySet<Room>().toMutableSet(), mutableSetOf(
                 TalkSlot(LocalTime.parse("09:00"), LocalTime.parse("10:00")),
                 TalkSlot(LocalTime.parse("10:00"), LocalTime.parse("11:00")),
                 TalkSlot(LocalTime.parse("11:00"), LocalTime.parse("12:00"))
@@ -32,9 +32,8 @@ class OpenSpaceTest {
     @Test
     fun `an open space is created with necessary fields and contains them`() {
         val nameOpenSpace = "os"
-        val date = LocalDate.now()
         val openSpace = OpenSpace(
-            nameOpenSpace, emptySet(), emptySet()
+            nameOpenSpace, emptySet<Room>().toMutableSet(), emptySet<Slot>().toMutableSet()
         )
 
         assertEquals(openSpace.name, nameOpenSpace)
@@ -43,10 +42,9 @@ class OpenSpaceTest {
     @Test
     fun `an open space is created with description and contains it`() {
         val nameOpenSpace = "os"
-        val date = LocalDate.now()
         val description = "A description"
         val openSpace = OpenSpace(
-            nameOpenSpace, emptySet(), emptySet(),
+            nameOpenSpace, emptySet<Room>().toMutableSet(), emptySet<Slot>().toMutableSet(),
             mutableSetOf(), description
         )
 
@@ -174,8 +172,8 @@ class OpenSpaceTest {
     fun `an open space is created with a track`() {
         val track = Track(name = "track", color = "#FFFFFF")
         val openSpace = OpenSpace(
-            name = "os", rooms = emptySet(), slots = emptySet(),
-            talks = mutableSetOf(), tracks = setOf(track)
+            name = "os", rooms = emptySet<Room>().toMutableSet(), slots = emptySet<Slot>().toMutableSet(),
+            talks = mutableSetOf(), tracks = mutableSetOf(track)
         )
 
         assertEquals(1, openSpace.tracks.size)
@@ -259,7 +257,7 @@ class OpenSpaceTest {
         val openSpace = anyOpenSpaceWith(organizer)
 
         assertThrows<NotTheOrganizerException> {
-            openSpace.update(aUser, "a new name")
+            openSpace.update(aUser, "a new name", "")
         }
     }
 
@@ -294,7 +292,7 @@ class OpenSpaceTest {
         val first_date_slot = TalkSlot(LocalTime.of(9, 0), LocalTime.of(10, 0), startDate)
         val end_date_slot = TalkSlot(LocalTime.of(9, 0), LocalTime.of(10, 0), endDate)
         val openSpace = OpenSpace(
-            name = "os", rooms = emptySet(), slots = setOf(first_date_slot, end_date_slot),
+            name = "os", rooms = emptySet<Room>().toMutableSet(), slots = mutableSetOf(first_date_slot, end_date_slot),
             talks = mutableSetOf()
         )
         return openSpace

--- a/back/src/test/kotlin/com/sos/smartopenspace/domain/OpenSpaceTest.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/domain/OpenSpaceTest.kt
@@ -12,7 +12,7 @@ class OpenSpaceTest {
 
     private fun anyOpenSpace(talks: MutableSet<Talk> = mutableSetOf()) =
         OpenSpace(
-            "os", emptySet<Room>().toMutableSet(), mutableSetOf(
+            "os", mutableSetOf(), mutableSetOf(
                 TalkSlot(LocalTime.parse("09:00"), LocalTime.parse("10:00")),
                 TalkSlot(LocalTime.parse("10:00"), LocalTime.parse("11:00")),
                 TalkSlot(LocalTime.parse("11:00"), LocalTime.parse("12:00"))
@@ -33,7 +33,7 @@ class OpenSpaceTest {
     fun `an open space is created with necessary fields and contains them`() {
         val nameOpenSpace = "os"
         val openSpace = OpenSpace(
-            nameOpenSpace, emptySet<Room>().toMutableSet(), emptySet<Slot>().toMutableSet()
+            nameOpenSpace, mutableSetOf(), mutableSetOf()
         )
 
         assertEquals(openSpace.name, nameOpenSpace)
@@ -44,7 +44,7 @@ class OpenSpaceTest {
         val nameOpenSpace = "os"
         val description = "A description"
         val openSpace = OpenSpace(
-            nameOpenSpace, emptySet<Room>().toMutableSet(), emptySet<Slot>().toMutableSet(),
+            nameOpenSpace, mutableSetOf(), mutableSetOf(),
             mutableSetOf(), description
         )
 
@@ -172,7 +172,7 @@ class OpenSpaceTest {
     fun `an open space is created with a track`() {
         val track = Track(name = "track", color = "#FFFFFF")
         val openSpace = OpenSpace(
-            name = "os", rooms = emptySet<Room>().toMutableSet(), slots = emptySet<Slot>().toMutableSet(),
+            name = "os", rooms = mutableSetOf(), slots = mutableSetOf(),
             talks = mutableSetOf(), tracks = mutableSetOf(track)
         )
 
@@ -292,7 +292,7 @@ class OpenSpaceTest {
         val first_date_slot = TalkSlot(LocalTime.of(9, 0), LocalTime.of(10, 0), startDate)
         val end_date_slot = TalkSlot(LocalTime.of(9, 0), LocalTime.of(10, 0), endDate)
         val openSpace = OpenSpace(
-            name = "os", rooms = emptySet<Room>().toMutableSet(), slots = mutableSetOf(first_date_slot, end_date_slot),
+            name = "os", rooms = mutableSetOf(), slots = mutableSetOf(first_date_slot, end_date_slot),
             talks = mutableSetOf()
         )
         return openSpace

--- a/back/src/test/kotlin/com/sos/smartopenspace/repositories/OpenSpaceRepositoryTest.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/repositories/OpenSpaceRepositoryTest.kt
@@ -1,8 +1,12 @@
 package com.sos.smartopenspace.repositories
 
+import com.sos.smartopenspace.aUser
 import com.sos.smartopenspace.anOpenSpace
+import com.sos.smartopenspace.domain.OpenSpace
 import com.sos.smartopenspace.domain.Track
+import com.sos.smartopenspace.domain.User
 import com.sos.smartopenspace.persistence.OpenSpaceRepository
+import com.sos.smartopenspace.persistence.UserRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -23,6 +27,9 @@ class OpenSpaceRepositoryTest {
 
     @Autowired
     lateinit var entityManager: EntityManager
+
+    @Autowired
+    lateinit var repoUser: UserRepository
 
     @Test
     fun `a track cannot be saved with description over 500 characters`() {
@@ -81,10 +88,18 @@ class OpenSpaceRepositoryTest {
 
     @Test
     fun `the name of an open space can be modified and it is updated successfully`() {
-        val openSpace = anOpenSpace();
+        val organizer = repoUser.save(aUser())
+        val openSpace = createOpenSpaceFor(organizer)
         repoOpenSpace.save(openSpace)
-        openSpace.update(openSpace.organizer, name = "A new name")
+        openSpace.update(openSpace.organizer, name = "A new name", description = "")
         val updatedOpenSpace = repoOpenSpace.findById(openSpace.id).get()
         assertEquals("A new name", updatedOpenSpace.name)
+    }
+
+    private fun createOpenSpaceFor(user: User): OpenSpace {
+        val anOpenSpace = anOpenSpace()
+        user.addOpenSpace(anOpenSpace)
+        repoOpenSpace.save(anOpenSpace)
+        return anOpenSpace
     }
 }

--- a/front/src/App/EditOpenSpace/DateTab.js
+++ b/front/src/App/EditOpenSpace/DateTab.js
@@ -3,7 +3,7 @@ import { Box, Text, Button } from 'grommet';
 import ButtonNew from '#shared/ButtonNew';
 import HourHeader from '#shared/HourHeader';
 import PropTypes from 'prop-types';
-
+import { getLastEndFromCollectionOfSlots } from '#helpers/time';
 import { TrashIcon } from '#shared/icons';
 
 const TALK_SLOT = 'TalkSlot';
@@ -41,7 +41,7 @@ CloseSlot.propTypes = {
 };
 
 export const DateTab = ({ value, addSlot, removeSlot, date }) => {
-  const lastEnd = value.length > 0 ? value.slice(-1)[0].endTime : undefined;
+  const lastEnd = getLastEndFromCollectionOfSlots(value);
 
   return (
     <>

--- a/front/src/App/EditOpenSpace/DateTab.js
+++ b/front/src/App/EditOpenSpace/DateTab.js
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Box, Text, Button } from 'grommet';
+import ButtonNew from '#shared/ButtonNew';
+import HourHeader from '#shared/HourHeader';
+import PropTypes from 'prop-types';
+
+import { TrashIcon } from '#shared/icons';
+
+const TALK_SLOT = 'TalkSlot';
+const OTHER_SLOT = 'OtherSlot';
+
+const Slot = ({ color, onRemove, start, text }) => (
+  <>
+    <HourHeader hour={start} />
+    <Box
+      background={{ color, opacity: 'medium' }}
+      direction="row"
+      justify="center"
+      pad={onRemove ? 'small' : 'medium'}
+      round="small"
+    >
+      <Text alignSelf="center" color="dark-1">
+        {text}
+      </Text>
+      {onRemove && <Button icon={<TrashIcon color="neutral-4" />} onClick={onRemove} />}
+    </Box>
+  </>
+);
+Slot.propTypes = {
+  color: PropTypes.string.isRequired,
+  onRemove: PropTypes.func,
+  start: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+};
+
+const CloseSlot = ({ time }) => (
+  <Slot color="accent-1" key={`cierre-${time}`} start={time} text="Cierre" />
+);
+CloseSlot.propTypes = {
+  time: PropTypes.string.isRequired,
+};
+
+export const DateTab = ({ value, addSlot, date, onChange }) => {
+  const lastEnd = value.length > 0 ? value.slice(-1)[0].endTime : undefined;
+
+  return (
+    <>
+      {value.map(({ type, startTime, description }, i) => (
+        <Slot
+          color={type === TALK_SLOT ? 'brand' : 'accent-1'}
+          key={startTime}
+          start={startTime}
+          text={type === TALK_SLOT ? 'Charla' : description}
+          onRemove={
+            i === value.length - 1
+              ? () => onChange({ target: { value: value.slice(0, -1) } })
+              : null
+          }
+        />
+      ))}
+      {value.length > 0 && <CloseSlot time={lastEnd} />}
+
+      <Box direction="row" margin={{ vertical: 'medium' }} justify="evenly">
+        <ButtonNew
+          label="Slot de Charla"
+          onClick={() => addSlot(TALK_SLOT, date, lastEnd)}
+        />
+        <ButtonNew
+          label="Slot Miscelaneo"
+          color="accent-1"
+          onClick={() => addSlot(OTHER_SLOT, date, lastEnd)}
+        />
+      </Box>
+    </>
+  );
+};
+DateTab.prototype = {
+  value: PropTypes.arrayOf(PropTypes.shape()).isRequired,
+  addSlot: PropTypes.func.isRequired,
+};

--- a/front/src/App/EditOpenSpace/DateTab.js
+++ b/front/src/App/EditOpenSpace/DateTab.js
@@ -40,7 +40,7 @@ CloseSlot.propTypes = {
   time: PropTypes.string.isRequired,
 };
 
-export const DateTab = ({ value, addSlot, date, onChange }) => {
+export const DateTab = ({ value, addSlot, removeSlot, date }) => {
   const lastEnd = value.length > 0 ? value.slice(-1)[0].endTime : undefined;
 
   return (
@@ -51,11 +51,7 @@ export const DateTab = ({ value, addSlot, date, onChange }) => {
           key={startTime}
           start={startTime}
           text={type === TALK_SLOT ? 'Charla' : description}
-          onRemove={
-            i === value.length - 1
-              ? () => onChange({ target: { value: value.slice(0, -1) } })
-              : null
-          }
+          onRemove={i === value.length - 1 ? () => removeSlot(date, lastEnd) : null}
         />
       ))}
       {value.length > 0 && <CloseSlot time={lastEnd} />}

--- a/front/src/App/EditOpenSpace/Dates.js
+++ b/front/src/App/EditOpenSpace/Dates.js
@@ -8,31 +8,31 @@ import MyCalendar from './MyCalendar';
 import ListWithRemoveButton from '#shared/ListWithRemoveButton';
 
 const Dates = ({ value, onChange }) => {
-  const initialValue = { date: '' };
-  const [date, setDate] = useState(initialValue);
-  const isDateEmpty = date.date.trim().length < 1;
-  const isDateIncluded = value.some((eachDate) => eachDate.date === date.date);
+  const initialDate = '';
+  const [date, setDate] = useState(initialDate);
+  const isDateEmpty = date.trim().length < 1;
+  const isDateIncluded = value.some((eachDate) => eachDate === date);
   return (
     <Box pad="small">
       <RowBetween>
         <MyCalendar
-          onChange={(event) => setDate({ date: event.target.value })}
+          onChange={(event) => setDate(event.target.value)}
           placeholder="Fechas del Open Space"
-          value={date.date}
+          value={date}
         />
         <PlusButton
           conditionToDisable={isDateEmpty || isDateIncluded}
-          item={date}
+          item={new Date(date)}
           setItem={setDate}
           value={value}
-          initialItem={initialValue}
+          initialItem={date}
           onChange={onChange}
         />
       </RowBetween>
       <ListWithRemoveButton
         items={value}
         onChange={onChange}
-        displayName={(item) => new Date(item.date).toLocaleDateString('es')}
+        displayName={(item) => new Date(item).toLocaleDateString('es')}
       />
     </Box>
   );

--- a/front/src/App/EditOpenSpace/Dates.js
+++ b/front/src/App/EditOpenSpace/Dates.js
@@ -7,7 +7,7 @@ import { PlusButton } from '#shared/PlusButton';
 import MyCalendar from './MyCalendar';
 import ListWithRemoveButton from '#shared/ListWithRemoveButton';
 
-const Dates = ({ value, onChange }) => {
+const Dates = ({ value, onChange, onRemoveItem }) => {
   const initialDate = '';
   const [date, setDate] = useState(initialDate);
   const isDateEmpty = date.trim().length < 1;
@@ -33,6 +33,7 @@ const Dates = ({ value, onChange }) => {
         items={value}
         onChange={onChange}
         displayName={(item) => new Date(item).toLocaleDateString('es')}
+        onRemoveItem={onRemoveItem}
       />
     </Box>
   );

--- a/front/src/App/EditOpenSpace/EditOpenSpace.js
+++ b/front/src/App/EditOpenSpace/EditOpenSpace.js
@@ -7,19 +7,36 @@ import { RedirectToRoot, usePushToRoot } from '#helpers/routes';
 import { OpenSpaceForm } from './OpenSpaceForm';
 import Spinner from '#shared/Spinner';
 
+function formatTime(timeArray) {
+  let hour = timeArray[0].toString().padStart(2, '0');
+  let minute = timeArray[1].toString().padStart(2, '0');
+  return `${hour}:${minute}`;
+}
+
 const EditOpenSpace = () => {
   const history = useHistory();
   const user = useUser();
   const pushToRoot = usePushToRoot();
 
   const { data: openSpace, isPending } = useGetOpenSpace();
-  if (isPending) return <Spinner />;
+  if (isPending) {
+    return <Spinner />;
+  } else {
+    openSpace.slots.sort(
+      (slotA, slotB) =>
+        slotA.startTime[0] - slotB.startTime[0] || slotA.startTime[1] - slotB.startTime[1]
+    );
+    openSpace.slots.forEach((slot) => {
+      slot.startTime = formatTime(slot.startTime);
+      slot.endTime = formatTime(slot.endTime);
+    });
+  }
 
   if (!user) return <RedirectToRoot />;
 
-  const onSubmit = ({ value: { name } }) => {
-    openSpace.name = name;
-    updateOS(openSpace.id, openSpace).then(pushToRoot);
+  const onSubmit = ({ value }) => {
+    const editedOpenSpace = { ...openSpace, ...value };
+    updateOS(openSpace.id, editedOpenSpace).then(pushToRoot);
   };
 
   return (

--- a/front/src/App/EditOpenSpace/NewOpenSpace.js
+++ b/front/src/App/EditOpenSpace/NewOpenSpace.js
@@ -15,7 +15,7 @@ const NewOpenSpace = () => {
 
   const onSubmit = ({ value: { dates, name, description, rooms, slots, tracks } }) => {
     createOS({
-      dates: dates.map((date) => new Date(date.date)),
+      dates: dates.map((date) => new Date(date)),
       name,
       description,
       rooms,

--- a/front/src/App/EditOpenSpace/OpenSpaceForm.js
+++ b/front/src/App/EditOpenSpace/OpenSpaceForm.js
@@ -126,7 +126,7 @@ export const OpenSpaceForm = ({
   isNewOpenSpace,
 }) => {
   const [showInputSlot, setShowInputSlot] = useState(null);
-  const [avaialbleDates, setAvailableDates] = useState(initialValues.dates || []);
+  const [availableDates, setAvailableDates] = useState(initialValues.dates || []);
 
   function isRepeated(tracks, track) {
     return tracks.filter((eachTrack) => eachTrack.name === track.name).length > 1;
@@ -158,7 +158,7 @@ export const OpenSpaceForm = ({
       <MyForm onSecondary={history.goBack} onSubmit={onSubmit}>
         <MyForm.Text placeholder="¿Como se va a llamar?" value={initialValues.name} />
         <MyForm.TextAreaWithCharacterCounter
-          placeholder="Añade una descripcion."
+          placeholder="Añade una descripción."
           maxLength={1000}
           value={initialValues.description}
         />
@@ -213,7 +213,7 @@ export const OpenSpaceForm = ({
               return 'Ingresa al menos un slot';
             }
           }}
-          dates={avaialbleDates}
+          dates={availableDates}
           value={initialValues.slots}
         />
       </MyForm>

--- a/front/src/App/EditOpenSpace/OpenSpaceForm.js
+++ b/front/src/App/EditOpenSpace/OpenSpaceForm.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
 import Title from '#shared/Title';
 import Detail from '#shared/Detail';
 import Spinner from '#shared/Spinner';
+import { byDate } from '#helpers/time';
 
 const OTHER_SLOT = 'OtherSlot';
 
@@ -123,10 +124,10 @@ export const OpenSpaceForm = ({
   history,
   title,
   initialValues = emptyOpenSpace,
-  isNewOpenSpace,
 }) => {
   const [showInputSlot, setShowInputSlot] = useState(null);
   const [availableDates, setAvailableDates] = useState(initialValues.dates || []);
+  const [deletedDate, setDeletedDate] = useState();
 
   function isRepeated(tracks, track) {
     return tracks.filter((eachTrack) => eachTrack.name === track.name).length > 1;
@@ -196,6 +197,7 @@ export const OpenSpaceForm = ({
                 return 'Ingresa al menos una fecha';
               }
             }}
+            onRemoveItem={(date) => setDeletedDate(date)}
             onChange={(event) => setAvailableDates(event.target.value)}
             value={initialValues.dates || []}
           />
@@ -213,6 +215,7 @@ export const OpenSpaceForm = ({
               return 'Ingresa al menos un slot';
             }
           }}
+          deletedDate={deletedDate}
           dates={availableDates}
           value={initialValues.slots}
         />

--- a/front/src/App/EditOpenSpace/OpenSpaceForm.js
+++ b/front/src/App/EditOpenSpace/OpenSpaceForm.js
@@ -126,6 +126,7 @@ export const OpenSpaceForm = ({
   isNewOpenSpace,
 }) => {
   const [showInputSlot, setShowInputSlot] = useState(null);
+  const [avaialbleDates, setAvailableDates] = useState(initialValues.dates || []);
 
   function isRepeated(tracks, track) {
     return tracks.filter((eachTrack) => eachTrack.name === track.name).length > 1;
@@ -156,73 +157,65 @@ export const OpenSpaceForm = ({
       </MainHeader>
       <MyForm onSecondary={history.goBack} onSubmit={onSubmit}>
         <MyForm.Text placeholder="¿Como se va a llamar?" value={initialValues.name} />
-        {isNewOpenSpace && (
-          <MyForm.TextAreaWithCharacterCounter
-            placeholder="Añade una descripcion."
-            maxLength={1000}
-            value={initialValues.description}
-          />
-        )}
-        {isNewOpenSpace && (
+        <MyForm.TextAreaWithCharacterCounter
+          placeholder="Añade una descripcion."
+          maxLength={1000}
+          value={initialValues.description}
+        />
+        <MyForm.Field
+          component={Tracks}
+          icon={<TracksIcon />}
+          label="Tracks"
+          name="tracks"
+          validate={(tracks) => {
+            if (hasTracksWithRepeatedName(tracks))
+              return 'No puede haber dos tracks con el mismo nombre';
+          }}
+          value={initialValues.tracks || []}
+        />
+        <MyForm.Field
+          component={Rooms}
+          icon={<HomeIcon />}
+          label="Salas"
+          name="rooms"
+          validate={(rooms) => {
+            if (hasRooms(rooms)) {
+              return 'Ingresa al menos una sala';
+            }
+          }}
+          value={initialValues.rooms || []}
+        />
+        <Box direction="row">
           <MyForm.Field
-            component={Tracks}
-            icon={<TracksIcon />}
-            label="Tracks"
-            name="tracks"
-            validate={(tracks) => {
-              if (hasTracksWithRepeatedName(tracks))
-                return 'No puede haber dos tracks con el mismo nombre';
-            }}
-            value={initialValues.tracks || []}
-          />
-        )}
-        {isNewOpenSpace && (
-          <MyForm.Field
-            component={Rooms}
-            icon={<HomeIcon />}
-            label="Salas"
-            name="rooms"
-            validate={(rooms) => {
-              if (hasRooms(rooms)) {
-                return 'Ingresa al menos una sala';
+            component={Dates}
+            icon={<CalendarIcon />}
+            label="Fecha"
+            name="dates"
+            validate={(dates) => {
+              if (hasDates(dates)) {
+                return 'Ingresa al menos una fecha';
               }
             }}
-            value={initialValues.rooms || []}
+            onChange={(event) => setAvailableDates(event.target.value)}
+            value={initialValues.dates || []}
           />
-        )}
-        {isNewOpenSpace && (
-          <Box direction="row">
-            <MyForm.Field
-              component={Dates}
-              icon={<CalendarIcon />}
-              label="Fecha"
-              name="dates"
-              validate={(dates) => {
-                if (hasDates(dates)) {
-                  return 'Ingresa al menos una fecha';
-                }
-              }}
-              value={initialValues.dates || []}
-            />
-          </Box>
-        )}
-        {isNewOpenSpace && (
-          <MyForm.Field
-            component={TimeSelector}
-            icon={<ClockIcon />}
-            label="Grilla Horaria"
-            name="slots"
-            onNewSlot={(type, start, onSubmitSlot) => {
-              setShowInputSlot({ onSubmitSlot, start, type });
-            }}
-            validate={(times) => {
-              if (hasSlots(times)) {
-                return 'Ingresa al menos un slot';
-              }
-            }}
-            value={initialValues.slots}
-          />
-        )}
+        </Box>
+        <MyForm.Field
+          component={TimeSelector}
+          icon={<ClockIcon />}
+          label="Grilla Horaria"
+          name="slots"
+          onNewSlot={(type, start, onSubmitSlot) => {
+            setShowInputSlot({ onSubmitSlot, start, type });
+          }}
+          validate={(times) => {
+            if (hasSlots(times)) {
+              return 'Ingresa al menos un slot';
+            }
+          }}
+          dates={avaialbleDates}
+          value={initialValues.slots}
+        />
       </MyForm>
       {showInputSlot !== null && (
         <InputSlot

--- a/front/src/App/EditOpenSpace/TimeSelector.js
+++ b/front/src/App/EditOpenSpace/TimeSelector.js
@@ -28,6 +28,13 @@ const TimeSelector = ({ onChange, onNewSlot, value, dates }) => {
       });
     });
 
+  const removeSlot = (date, lastEnd) =>
+    onChange({
+      target: {
+        value: value.filter((slot) => !byDate(date)(slot) || slot.endTime != lastEnd),
+      },
+    });
+
   return (
     <Box>
       <Tabs>
@@ -38,7 +45,7 @@ const TimeSelector = ({ onChange, onNewSlot, value, dates }) => {
               value={value.filter(byDate(date))}
               addSlot={addSlot}
               date={date}
-              onChange={onChange}
+              removeSlot={removeSlot}
             />
           </Tab>
         ))}

--- a/front/src/App/EditOpenSpace/TimeSelector.js
+++ b/front/src/App/EditOpenSpace/TimeSelector.js
@@ -2,12 +2,8 @@ import React from 'react';
 import { Box, Tabs, Tab } from 'grommet';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
-
-import { toDate } from '#helpers/time';
-import { isEqual } from 'date-fns';
 import { DateTab } from './DateTab';
-
-const byDate = (date) => (slot) => isEqual(toDate(slot.date), date);
+import { byDate } from '#helpers/time';
 
 const TimeSelector = ({ onChange, onNewSlot, value, dates }) => {
   const addSlot = (type, date, lastEnd) =>

--- a/front/src/App/EditOpenSpace/TimeSelector.js
+++ b/front/src/App/EditOpenSpace/TimeSelector.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Box, Tabs, Tab } from 'grommet';
 import PropTypes from 'prop-types';
 import { format } from 'date-fns';
 import { DateTab } from './DateTab';
 import { byDate } from '#helpers/time';
 
-const TimeSelector = ({ onChange, onNewSlot, value, dates }) => {
+const TimeSelector = ({ onChange, onNewSlot, value, dates, deletedDate }) => {
   const addSlot = (type, date, lastEnd) =>
     onNewSlot(type, lastEnd, ({ value: { startTime, endTime, description } }) => {
       onChange({
@@ -30,6 +30,12 @@ const TimeSelector = ({ onChange, onNewSlot, value, dates }) => {
         value: value.filter((slot) => !byDate(date)(slot) || slot.endTime != lastEnd),
       },
     });
+
+  useEffect(() => {
+    onChange({
+      target: { value: value.filter((slot) => !byDate(deletedDate)(slot)) },
+    });
+  }, [deletedDate]);
 
   return (
     <Box>

--- a/front/src/App/EditOpenSpace/Tracks.js
+++ b/front/src/App/EditOpenSpace/Tracks.js
@@ -48,7 +48,7 @@ const Tracks = ({ value, onChange }) => {
           </RowBetween>
           <Box>
             <TextAreaWithCharacterCounter
-              placeholder="Descripcion"
+              placeholder="Descripción"
               value={track.description}
               maxLength={500}
               onChange={(event) =>

--- a/front/src/App/OpenSpace/schedule/Schedule.js
+++ b/front/src/App/OpenSpace/schedule/Schedule.js
@@ -11,7 +11,7 @@ import {
 import Spinner from '#shared/Spinner';
 import { useUser } from '#helpers/useAuth';
 import { ButtonSingIn } from '#shared/ButtonSingIn';
-import { sortTimes, toDate } from '#helpers/time';
+import { sortTimes, byDate } from '#helpers/time';
 import { DateSlots } from './DateSlots';
 import { Tab, Tabs } from 'grommet';
 import { compareAsc, format, isEqual } from 'date-fns';
@@ -38,7 +38,6 @@ const Schedule = () => {
   const talksOf = (slotId) =>
     slotsSchedule.filter((slotSchedule) => slotSchedule.slot.id === slotId);
   const amTheOrganizer = user && organizer.id === user.id;
-  const byDate = (date) => (slot) => isEqual(toDate(slot.date), date);
 
   return (
     <>

--- a/front/src/App/model/room.js
+++ b/front/src/App/model/room.js
@@ -1,8 +1,7 @@
-import { compareAsc, isEqual } from 'date-fns';
-import { compareTime } from '#helpers/time';
+import { compareAsc } from 'date-fns';
+import { compareTime, byDate, toDate } from '#helpers/time';
 
 export class Room {
-  byDate = (date) => (slot) => isEqual(this._toDate(slot.date), date);
   byTime = (aSlot, otherSlot) => compareTime(aSlot.startTime, otherSlot.startTime);
   constructor(slots, id, name, description) {
     this._slots = slots;
@@ -13,15 +12,11 @@ export class Room {
 
   slots() {
     return this._slots.sort((aSlot, otherSlot) =>
-      compareAsc(this._toDate(aSlot.date), this._toDate(otherSlot.date))
+      compareAsc(toDate(aSlot.date), toDate(otherSlot.date))
     );
   }
 
-  _toDate(date) {
-    return new Date(date[0], date[1] - 1, date[2]);
-  }
-
   slotsAt(date) {
-    return this._slots.filter(this.byDate(date)).sort(this.byTime);
+    return this._slots.filter(byDate(date)).sort(this.byTime);
   }
 }

--- a/front/src/helpers/time.js
+++ b/front/src/helpers/time.js
@@ -1,3 +1,5 @@
+import { isEqual } from 'date-fns';
+
 export const numberToTwoDigitNumber = (number) => (number < 10 ? '0' : '') + number;
 
 export const numbersToTime = (number) => number.map(numberToTwoDigitNumber).join(':');
@@ -12,3 +14,8 @@ export const sortTimes = (times) =>
   );
 
 export const toDate = ([year, month, day]) => new Date(year, month - 1, day);
+
+export const byDate = (date) => (slot) => isEqual(toDate(slot.date), date);
+
+export const getLastEndFromCollectionOfSlots = (slots) =>
+  slots.length > 0 ? slots.slice(-1)[0].endTime : undefined;

--- a/front/src/shared/ListWithRemoveButton.js
+++ b/front/src/shared/ListWithRemoveButton.js
@@ -21,7 +21,12 @@ Item.propTypes = {
   itemName: PropTypes.string.isRequired,
 };
 
-const ListWithRemoveButton = ({ items, onChange, displayName = (item) => item.name }) => {
+const ListWithRemoveButton = ({
+  items,
+  onChange,
+  displayName = (item) => item.name,
+  onRemoveItem = (item) => {},
+}) => {
   return (
     <List>
       {items.map((item, itemIndex) => (
@@ -29,11 +34,12 @@ const ListWithRemoveButton = ({ items, onChange, displayName = (item) => item.na
           color={item.color}
           key={itemIndex}
           itemName={displayName(item)}
-          onRemove={() =>
+          onRemove={() => {
+            onRemoveItem(item);
             onChange({
               target: { value: items.filter((_, index) => index !== itemIndex) },
-            })
-          }
+            });
+          }}
         />
       ))}
     </List>


### PR DESCRIPTION
Se agrego a la pantalla de edicion de open space, todos los campos del open space para que puedan ser modificados
![image](https://user-images.githubusercontent.com/48839912/216135419-237ef6cb-dcfa-4996-b856-16a6b59b7064.png)
![image](https://user-images.githubusercontent.com/48839912/216135689-f40c25f9-22f6-46f3-b735-b9ecc4a88667.png)


En este cambio tambien se refactorizo la creacion de slots para que los mismo puedan ser distitnos entre distintas fechas de un mismo open space

Y se refactorizo la forma en que se manejaba un valor date en el frontend
de `date: { date }` a `date`
![image](https://user-images.githubusercontent.com/48839912/216136493-851a1139-25cf-4a33-8d2e-0eaa1fcc8f49.png)

