### PR TITLE
fix talk test

### DIFF
--- a/back/src/test/kotlin/com/sos/smartopenspace/controllers/OpenSpaceControllerTest.kt
+++ b/back/src/test/kotlin/com/sos/smartopenspace/controllers/OpenSpaceControllerTest.kt
@@ -121,18 +121,16 @@ class OpenSpaceControllerTest {
         val aMeetingLink = "https://aLink"
         val aDocument = Document("a document", URL("https://www.lipsum.com/"))
 
-        val entityResponse = mockMvc.perform(
+        mockMvc.perform(
             MockMvcRequestBuilders.post("/openSpace/talk/${user.id}/${anOpenSpace.id}")
                 .contentType("application/json")
                 .content(generateTalkWithTrackBody(aMeetingLink, track, document = aDocument))
-        ).andExpect(MockMvcResultMatchers.status().isOk).andReturn().response
+        ).andExpect(MockMvcResultMatchers.status().isOk)
 
-        val talkId = JsonPath.read<Int>(entityResponse.contentAsString, "$.id")
         mockMvc.perform(
             MockMvcRequestBuilders.get("/openSpace/talks/${anOpenSpace.id}")
         )
             .andExpect(MockMvcResultMatchers.status().isOk)
-            .andExpect(MockMvcResultMatchers.jsonPath("$[0].id").value(talkId))
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].meetingLink").value(aMeetingLink))
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].track.name").value(track.name))
             .andExpect(MockMvcResultMatchers.jsonPath("$[0].documents[0].name").value(aDocument.name))


### PR DESCRIPTION
Como se borro del metodo de creacipn de talks el talkRepository.save() ya no se estaba retornando el id de la charla creada (A pesar de que esta se creaba correctamente en la db con su trespectivo id)

Por lo cual se decidio moficar el test para que corresponda con estos cambios y se saco el chequeo del id